### PR TITLE
fix: Buttons persistent nach React-Re-Render (3.3.3)

### DIFF
--- a/kleinanzeigen-duplizieren.user.js
+++ b/kleinanzeigen-duplizieren.user.js
@@ -5,7 +5,7 @@
 // @icon          https://www.google.com/s2/favicons?domain=www.kleinanzeigen.de
 // @copyright     2026
 // @license       MIT
-// @version       3.3.2
+// @version       3.3.3
 // @author        OldRon1977 (Improvements), J05HI (Original)
 // @credits       Basierend auf dem Original-Script von J05HI (https://gist.github.com/J05HI/9f3fc7a496e8baeff5a56e0c1a710bb5)
 // @match         https://www.kleinanzeigen.de/p-anzeige-bearbeiten.html*
@@ -393,7 +393,7 @@
 
     // === INITIALISIERUNG ===
     function init() {
-        logger.log('UserScript initialisiert (v3.3.2)');
+        logger.log('UserScript initialisiert (v3.3.3)');
 
         function startOrRepublish() {
             if (window.location.hash === '#smartRepublish') {
@@ -401,6 +401,7 @@
                 smartRepublish();
             } else {
                 createButtons();
+                startButtonWatcher();
             }
         }
 
@@ -412,11 +413,25 @@
         }
     }
 
+    // === MUTATIONOBSERVER: Buttons nach React-Re-Render wiederherstellen ===
+    function startButtonWatcher() {
+        let debounceTimer;
+        const observer = new MutationObserver(function () {
+            // Nur reagieren wenn Buttons verschwunden sind
+            if (!document.querySelector('.ka-duplicate-btn')) {
+                clearTimeout(debounceTimer);
+                debounceTimer = setTimeout(function () {
+                    logger.log('Buttons verschwunden, stelle wieder her');
+                    buttonCreateRetries = 0;
+                    createButtons();
+                }, 500);
+            }
+        });
+        observer.observe(document.body, { childList: true, subtree: true });
+    }
+
     // Start
     init();
 
 })();
-
-
-
 


### PR DESCRIPTION
Buttons verschwanden nach kurzer Zeit weil React den DOM neu rendert.
MutationObserver stellt sie automatisch wieder her.