### PR TITLE
feat: Helper mit Duplizieren-Button, README ueberarbeitet (3.3.8 / 1.2.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,200 +1,117 @@
-﻿# eBay Kleinanzeigen - Anzeige duplizieren / Smart neu einstellen
+﻿# Kleinanzeigen - Anzeige duplizieren / Smart neu einstellen
 
-Ein UserScript fÃ¼r Tampermonkey, das zwei praktische Buttons zum Duplizieren und intelligenten Neu-Einstellen von Anzeigen auf eBay Kleinanzeigen/Kleinanzeigen.de hinzufÃ¼gt.
+Ein UserScript fuer Tampermonkey, das praktische Buttons zum Duplizieren und intelligenten Neu-Einstellen von Anzeigen auf kleinanzeigen.de hinzufuegt.
 
-## âœ¨ Features
+## Features
 
-- **ðŸ“‹ Duplizieren**: Erstellt eine Kopie der Anzeige, Original bleibt erhalten
-- **ðŸ”„ Smart neu einstellen**: LÃ¶scht das Original und erstellt eine neue Anzeige
-- **ðŸ–¼ï¸ Automatische Bilderhaltung**: Alle Bilder bleiben bei beiden Funktionen erhalten
-- **âš¡ Robust & Schnell**: Schlanker Code mit nur ~200 Zeilen
-- **ðŸ›¡ï¸ Fehlerbehandlung**: Timeout-Schutz und Retry-Mechanismen
+- **Duplizieren**: Erstellt eine Kopie der Anzeige, Original bleibt erhalten
+- **Smart neu einstellen**: Loescht das Original und erstellt eine neue Anzeige
+- **Automatische Bilderhaltung**: Alle Bilder bleiben bei beiden Funktionen erhalten
+- **Helper-Script**: Buttons direkt auf der "Meine Anzeigen"-Seite
+- **Fehlerbehandlung**: Timeout-Schutz und Retry-Mechanismen
 
-## ðŸ“¦ Installation
-
-### âš¡ Schnelle Installation
-
-[![Install Script](https://img.shields.io/badge/Install%20Script-Kleinanzeigen%20Duplizieren-00aa00?style=for-the-badge&logo=tampermonkey)](https://github.com/OldRon1977/Kleinanzeigen-Anzeigen-duplizieren/raw/main/kleinanzeigen-duplizieren.user.js)
-
-**Wie funktioniert es:**
-1. Klick auf den Button oben
-2. Tampermonkey Ã¶ffnet sich automatisch
-3. Klick "Installieren"
-4. Fertig! Script ist aktiv âœ…
-
-> **Hinweis**: Tampermonkey muss vorher installiert sein. Siehe [Voraussetzungen](#voraussetzungen) unten.
+## Installation
 
 ### Voraussetzungen
 - Browser: Chrome, Firefox, Edge, Safari oder Opera
 - [Tampermonkey](https://www.tampermonkey.net/) Browser-Extension
 
-**Tampermonkey installieren:**
-- [Chrome Web Store](https://chrome.google.com/webstore/detail/tampermonkey/dhdgffkkebhmkfjojejmpbldmpobfkfo)
-- [Firefox Add-ons](https://addons.mozilla.org/de/firefox/addon/tampermonkey/)
-- [Edge Add-ons](https://microsoftedge.microsoft.com/addons/detail/tampermonkey/iikmkjmpaadaobahmlepeloendndfphd)
-- [Safari App Store](https://apps.apple.com/de/app/tampermonkey/id1482490089)
+### Schritt 1: Hauptscript installieren (Pflicht)
 
-### Alternative Installationsmethoden
-Siehe [**INSTALL.md**](INSTALL.md) fÃ¼r:
-- Manuelle Installation
-- Copy-Paste Installation
-- Detaillierte Anleitung
-- Automatische Updates
+[![Install Script](https://img.shields.io/badge/Install-Hauptscript-00aa00?style=for-the-badge&logo=tampermonkey)](https://github.com/OldRon1977/Kleinanzeigen-Anzeigen-duplizieren/raw/main/kleinanzeigen-duplizieren.user.js)
 
-### âœ… Auto-Updates aktiviert
-Das Script erhÃ¤lt **automatisch Updates**:
-- Tampermonkey prÃ¼ft jede Woche nach neuen Versionen
-- Updates werden automatisch installiert
-- Du wirst benachrichtigt wenn eine neue Version verfÃ¼gbar ist
-- Keine zusÃ¤tzliche Aktion erforderlich!
+Fuegt auf der **Bearbeiten-Seite** einer Anzeige die Buttons "Duplizieren" und "Smart neu einstellen" hinzu.
 
-## ðŸŽ¯ Verwendung
+### Schritt 2: Helper-Script installieren (Empfohlen)
 
-1. **Anzeige bearbeiten**: Navigiere zu einer deiner Anzeigen und klicke auf "Bearbeiten"
-   ```
-   https://www.kleinanzeigen.de/p-anzeige-bearbeiten.html?adId=XXXXX
-   ```
+[![Install Helper](https://img.shields.io/badge/Install-Helper_Script-0077cc?style=for-the-badge&logo=tampermonkey)](https://github.com/OldRon1977/Kleinanzeigen-Anzeigen-duplizieren/raw/main/helper.user.js)
 
-2. **Neue Buttons nutzen**: Unter dem "Ã„nderungen speichern" Button erscheinen zwei neue Optionen:
+Fuegt auf der **Meine Anzeigen**-Seite neben jeder Anzeige die Buttons "Duplizieren" und "Neu einstellen" hinzu. Ein Klick oeffnet die Bearbeiten-Seite und fuehrt die Aktion automatisch aus.
 
-   ### ðŸ“‹ Duplizieren
-   - Erstellt eine exakte Kopie der Anzeige
-   - Original bleibt unverÃ¤ndert bestehen
-   - Alle Bilder und Daten werden Ã¼bernommen
-   - Ideal fÃ¼r: Ã„hnliche Artikel, Varianten, Backup
+> **Hinweis**: Beide Scripts muessen in Tampermonkey aktiviert sein, damit der Helper korrekt funktioniert.
 
-   ### ðŸ”„ Smart neu einstellen  
-   - LÃ¶scht die Original-Anzeige
-   - Erstellt automatisch eine neue Anzeige mit allen Daten
-   - Alle Bilder bleiben erhalten
-   - Ideal fÃ¼r: Anzeige erneuern, nach oben bringen
+### Auto-Updates
+Beide Scripts erhalten automatisch Updates ueber Tampermonkey.
 
-## ðŸ–¼ï¸ Bilder-Handhabung
+## Verwendung
 
-**Wichtig**: Alle Bilder bleiben automatisch erhalten!
+### Direkt auf der Bearbeiten-Seite
+1. Navigiere zu einer Anzeige und klicke "Bearbeiten"
+2. Unten rechts erscheint eine Toolbar mit zwei Buttons
+3. **Duplizieren**: Erstellt eine Kopie, Original bleibt bestehen
+4. **Smart neu einstellen**: Loescht Original, erstellt neue Anzeige
 
-Das Script nutzt die Tatsache, dass beim Bearbeiten einer Anzeige alle Bilder bereits im Formular geladen sind. Diese werden beim Submit automatisch mit Ã¼bertragen - egal ob die Original-ID vorhanden ist oder nicht.
+### Ueber die Meine-Anzeigen-Seite (Helper)
+1. Oeffne "Meine Anzeigen" auf kleinanzeigen.de
+2. Neben jedem "Bearbeiten"-Link erscheinen zwei neue Buttons
+3. Ein Klick oeffnet die Bearbeiten-Seite und fuehrt die Aktion automatisch aus
 
-## ðŸ”§ Technische Details
+## Technische Details
 
 ### Berechtigungen
-Das Script verwendet `@grant none` â€“ es hat keine erweiterten Tampermonkey-Berechtigungen
-und kann nur im Kontext der aktuellen Kleinanzeigen-Seite agieren. Es speichert keine Daten
-und kommuniziert ausschlieÃŸlich mit kleinanzeigen.de Ã¼ber HTTPS.
+Beide Scripts verwenden `@grant none` - keine erweiterten Tampermonkey-Berechtigungen. Sie kommunizieren ausschliesslich mit kleinanzeigen.de ueber HTTPS.
 
-### UnterstÃ¼tzte URLs
-- `https://www.kleinanzeigen.de/p-anzeige-bearbeiten.html*`
-- `https://kleinanzeigen.de/p-anzeige-bearbeiten.html*`
-- `https://*.kleinanzeigen.de/p-anzeige-bearbeiten.html*`
-- `https://www.ebay-kleinanzeigen.de/p-anzeige-bearbeiten.html*`
+### Unterstuetzte URLs
+- `https://www.kleinanzeigen.de/p-anzeige-bearbeiten.html*` (Hauptscript)
+- `https://www.kleinanzeigen.de/m-meine-anzeigen.html*` (Helper)
 
 ### API-Endpunkte
-- **LÃ¶schen**: `POST /m-anzeigen-loeschen.json?ids={adId}`
-- **CSRF-Token**: `meta[name="_csrf"]` oder `meta[name="csrf-token"]`
+- **Loeschen**: `POST /m-anzeigen-loeschen.json?ids={adId}`
+- **CSRF-Token**: `input[name="_csrf"]`
 
-### Browser-KompatibilitÃ¤t
-- âœ… Chrome/Chromium (v88+)
-- âœ… Firefox (v78+)
-- âœ… Edge (v88+)
-- âœ… Safari (v14+)
-- âœ… Opera (v74+)
+## Fehlerbehebung
 
-## ðŸ› Fehlerbehebung
+### Buttons erscheinen nicht auf der Bearbeiten-Seite
+- Warte 2-3 Sekunden nach dem Laden
+- Pruefe ob das Hauptscript in Tampermonkey aktiviert ist
+- Browser-Cache leeren (Strg+F5)
 
-### Script lÃ¤dt nicht
-1. PrÃ¼fe ob Tampermonkey aktiviert ist
-2. Stelle sicher, dass du auf der Bearbeiten-Seite bist
-3. Browser-Cache leeren (Strg+F5)
-4. Console Ã¶ffnen (F12) und nach Fehlern suchen
+### Buttons erscheinen nicht auf Meine Anzeigen
+- Pruefe ob das Helper-Script installiert und aktiviert ist
+- Tampermonkey-Icon sollte eine "2" anzeigen (beide Scripts aktiv)
 
-### Buttons erscheinen nicht
-- Warte 2-3 Sekunden nach Seitenladevorgang
-- Das Script sucht automatisch nach dem Submit-Button und platziert die neuen Buttons darunter
+### Loeschung schlaegt fehl
+- Session koennte abgelaufen sein - neu anmelden
+- Rate-Limiting - kurz warten und erneut versuchen
 
-### LÃ¶schung schlÃ¤gt fehl
-- Session kÃ¶nnte abgelaufen sein â†’ Neu anmelden
-- Rate-Limiting â†’ Kurz warten und erneut versuchen
+## Changelog
 
-## ðŸ“ Changelog
+### Version 3.3.8 / Helper 1.2.0 (April 2026)
+- Helper: Duplizieren-Button hinzugefuegt
+- Hauptscript: `#duplicate` Hash-Erkennung fuer Helper
+- README komplett ueberarbeitet
 
-### Version 3.2.1 (MÃ¤rz 2026) â­ Aktuell
-- ðŸ”§ Versions-Inkonsistenzen behoben (Fallback-Datei synchronisiert)
-- ðŸ”§ Tippfehler im Dateinamen korrigiert ("Kleinazeigen" â†’ "Kleinanzeigen")
-- ðŸ”§ Repository-URL in package.json korrigiert
-- ðŸ”§ TestzÃ¤hlungen in Dokumentation korrigiert
+### Version 3.3.7 (April 2026)
+- CSRF-Token aus Hidden Input lesen (Kleinanzeigen-Umbau)
+
+### Version 3.3.6 (April 2026)
+- Korrekter Ad-ID Selektor `input[name="adId"]`
+
+### Version 3.3.4-3.3.5 (April 2026)
+- Floating-Toolbar statt DOM-Injection (React-kompatibel)
+- `saveBtn.click()` statt `form.submit()`
+
+### Version 3.3.0-3.3.3 (Maerz 2026)
+- Helper-Script integriert
+- Selektoren an neues Kleinanzeigen-Layout angepasst
 
 ### Version 3.2.0 (Februar 2026)
-- ðŸ”’ Security-HÃ¤rtung nach ISO 27001/27002 Audit
-- âœ… Input-Validierung fÃ¼r Anzeigen-IDs (Defense-in-Depth)
-- âœ… Session-Timeout-Erkennung (401/403 â†’ hilfreiche Fehlermeldung)
-- âœ… Button-Disabling nach Klick (verhindert Doppelklick)
-- âœ… innerHTML durch createElement ersetzt (Code-Hygiene)
-- ðŸ“„ SECURITY.md hinzugefÃ¼gt (Responsible Disclosure)
-- ðŸ“„ .gitignore erstellt (Repository-Hygiene)
-- ðŸ“š Permissions-Dokumentation im README
-
-### Version 3.1.0 (November 2025)
-- âœ¨ Auto-Update Support aktiviert
-- ðŸ§ª 54 Unit & Integration Tests (100% bestanden)
-- ðŸ“š Umfangreiche Dokumentation
-- ðŸ”§ Exponential Backoff fÃ¼r Retries
-- ðŸ“ Logger System fÃ¼r Debugging
-- ðŸŽ¨ CSS Klassen mit Hover-Effekten
-- ðŸ›¡ï¸ Verbesserte Error-Handling
-- ðŸ“Š Code Quality Score: 8.9/10
+- Security-Haertung nach ISO 27001/27002 Review
 
 ### Version 3.0.0 (2025)
-- Komplette Code-Ãœberarbeitung
-- Von 600 auf ~362 Zeilen optimiert
+- Komplette Code-Ueberarbeitung
 - Smart Neu-Einstellen Feature
-- Retry-Limit mit Max-Versuchen
-- CSRF-Token Validation
-- User-Warnung bei LÃ¶sch-Fehler
 
-### Version 2.x (2024)
-- Erweiterte Bildanalyse (spÃ¤ter als unnÃ¶tig erkannt)
-- Komplexe Manager-Strukturen
+## Credits
 
-### Version 1.x (2024)
-- Initiale FunktionalitÃ¤t
-- Basis-Duplizierung
-
-## ðŸ‘¥ Credits & Lizenz
-
-### Credits
 - **Original-Script**: [J05HI](https://github.com/J05HI) - [Original Gist](https://gist.github.com/J05HI/9f3fc7a496e8baeff5a56e0c1a710bb5)
-  - Entwickelte die grundlegende Duplikations-FunktionalitÃ¤t
-  - API-Integration und CSRF-Token Handling
-  
+- **Helper-Idee**: [panzli](https://github.com/panzli)
 - **Erweiterte Version**: [OldRon1977](https://github.com/OldRon1977)
-  - Smart Neu-Einstellen Feature
-  - Verbesserte Fehlerbehandlung
-  - Code-Optimierungen
 
-### Lizenz
-MIT License - Siehe [LICENSE](LICENSE) fÃ¼r Details
+## Lizenz
 
-## ðŸ¤ Contributing
-
-Contributions sind willkommen! 
-
-1. Fork das Repository
-2. Erstelle einen Feature Branch (`git checkout -b feature/AmazingFeature`)
-3. Committe deine Ã„nderungen (`git commit -m 'Add some AmazingFeature'`)
-4. Push zum Branch (`git push origin feature/AmazingFeature`)
-5. Ã–ffne einen Pull Request
-
-## âš ï¸ Haftungsausschluss
-
-Dieses Script wird "as is" zur VerfÃ¼gung gestellt. Die Nutzung erfolgt auf eigene Gefahr. Die Autoren Ã¼bernehmen keine Haftung fÃ¼r eventuelle SchÃ¤den oder VerstÃ¶ÃŸe gegen die Nutzungsbedingungen von eBay Kleinanzeigen.
-
-## ðŸ“ž Support
-
-Bei Problemen oder Fragen:
-- [Issue erstellen](https://github.com/OldRon1977/Kleinanzeigen---Duplizieren-Smart-neu-einstellen/issues)
-- [Discussions](https://github.com/OldRon1977/Kleinanzeigen---Duplizieren-Smart-neu-einstellen/discussions)
+MIT License - Siehe [LICENSE](LICENSE)
 
 ---
 
-**Hinweis**: Dieses Script ist nicht offiziell mit eBay Kleinanzeigen verbunden oder von ihnen unterstÃ¼tzt.
-
+Dieses Script ist nicht offiziell mit Kleinanzeigen verbunden oder von ihnen unterstuetzt.

--- a/helper.user.js
+++ b/helper.user.js
@@ -1,11 +1,11 @@
 ﻿// ==UserScript==
-// @name          eBay Kleinanzeigen - neu einstellen helper
+// @name          Kleinanzeigen - Meine Anzeigen Helper
 // @namespace     https://github.com/OldRon1977/Kleinanzeigen-Anzeigen-duplizieren
-// @description   Hilfsskript fuer Smart Neu-Einstellen direkt aus "Meine Anzeigen"
+// @description   Duplizieren und Smart Neu-Einstellen direkt aus "Meine Anzeigen"
 // @icon          https://www.google.com/s2/favicons?domain=www.kleinanzeigen.de
 // @copyright     2026
 // @license       MIT
-// @version       1.1.2
+// @version       1.2.0
 // @author        panzli (Original), OldRon1977 (Anpassungen)
 // @match         https://www.kleinanzeigen.de/m-meine-anzeigen.html*
 // @match         https://kleinanzeigen.de/m-meine-anzeigen.html*
@@ -21,11 +21,11 @@
     'use strict';
 
     const MARKER = 'data-ka-smart-helper';
+    const BTN_STYLE = 'margin-left:6px;padding:3px 8px;cursor:pointer;border:1px solid #ccc;border-radius:4px;font-size:11px;vertical-align:middle;display:inline-flex;align-items:center;';
 
     function addControlButtons() {
         const elements = document.querySelectorAll('a[href*="/p-anzeige-bearbeiten.html?adId="]');
         elements.forEach(function (element) {
-            // Robuste Duplikat-Erkennung per data-Attribut statt nextSibling
             if (element.hasAttribute(MARKER)) return;
             element.setAttribute(MARKER, 'true');
 
@@ -33,36 +33,41 @@
             if (!match || !match[1]) return;
             const adId = match[1];
 
-            const btn = document.createElement('button');
-            btn.type = 'button';
-            btn.textContent = '\uD83D\uDD04 Smart neu einstellen';
-            btn.title = 'Loescht Original und erstellt neue Anzeige';
-            btn.style.cssText = 'margin-left:8px;padding:4px 10px;cursor:pointer;border:1px solid #ccc;border-radius:4px;background:#f5f5f5;font-size:12px;vertical-align:middle;display:inline-flex;align-items:center;';
+            // Duplizieren-Button
+            const dupBtn = document.createElement('button');
+            dupBtn.type = 'button';
+            dupBtn.textContent = '\uD83D\uDCCB Duplizieren';
+            dupBtn.title = 'Erstellt eine Kopie, Original bleibt erhalten';
+            dupBtn.style.cssText = BTN_STYLE + 'background:#f0f0f0;';
 
-            btn.onclick = function (e) {
+            dupBtn.onclick = function (e) {
                 e.preventDefault();
                 e.stopPropagation();
-                openSmartRepublish(adId, btn);
+                window.open('https://www.kleinanzeigen.de/p-anzeige-bearbeiten.html?adId=' + adId + '#duplicate', '_blank');
+                dupBtn.textContent = '\u2705 Geoeffnet';
             };
 
-            // Button direkt nach dem Bearbeiten-Link einfuegen
-            element.after(btn);
+            // Smart Neu Einstellen-Button
+            const smartBtn = document.createElement('button');
+            smartBtn.type = 'button';
+            smartBtn.textContent = '\uD83D\uDD04 Neu einstellen';
+            smartBtn.title = 'Loescht Original und erstellt neue Anzeige';
+            smartBtn.style.cssText = BTN_STYLE + 'background:#e8f4fd;';
+
+            smartBtn.onclick = function (e) {
+                e.preventDefault();
+                e.stopPropagation();
+                window.open('https://www.kleinanzeigen.de/p-anzeige-bearbeiten.html?adId=' + adId + '#smartRepublish', '_blank');
+                smartBtn.textContent = '\u2705 Geoeffnet';
+            };
+
+            element.after(smartBtn);
+            element.after(dupBtn);
         });
     }
 
-    function openSmartRepublish(adId, button) {
-        window.open(
-            'https://www.kleinanzeigen.de/p-anzeige-bearbeiten.html?adId=' + adId + '#smartRepublish',
-            '_blank'
-        );
-        button.style.color = 'red';
-        button.textContent = '\u2705 Geoeffnet';
-    }
-
-    // Initiale Ausfuehrung mit Verzoegerung fuer SPA-Rendering
     setTimeout(addControlButtons, 1500);
 
-    // MutationObserver mit Debounce gegen Performance-Probleme
     let debounceTimer;
     const observer = new MutationObserver(function () {
         clearTimeout(debounceTimer);

--- a/kleinanzeigen-duplizieren.user.js
+++ b/kleinanzeigen-duplizieren.user.js
@@ -5,7 +5,7 @@
 // @icon          https://www.google.com/s2/favicons?domain=www.kleinanzeigen.de
 // @copyright     2026
 // @license       MIT
-// @version       3.3.7
+// @version       3.3.8
 // @author        OldRon1977 (Improvements), J05HI (Original)
 // @credits       Basierend auf dem Original-Script von J05HI (https://gist.github.com/J05HI/9f3fc7a496e8baeff5a56e0c1a710bb5)
 // @match         https://www.kleinanzeigen.de/p-anzeige-bearbeiten.html*
@@ -424,9 +424,13 @@
         logger.log('UserScript initialisiert (v3.3.4)');
 
         function startOrRepublish() {
-            if (window.location.hash === '#smartRepublish') {
+            const hash = window.location.hash;
+            if (hash === '#smartRepublish') {
                 logger.log('Smart Republish via Helper erkannt');
                 smartRepublish();
+            } else if (hash === '#duplicate') {
+                logger.log('Duplizieren via Helper erkannt');
+                duplicateAd();
             } else {
                 createButtons();
             }


### PR DESCRIPTION
Helper 1.2.0: Duplizieren-Button. Hauptscript 3.3.8: #duplicate Hash. README: Umlaute/Emojis gefixt, Helper dokumentiert.