### PR TITLE
chore: add PROJEKTANWEISUNGEN.md to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ CRIT-001-SOLUTION.md
 
 # Kiro config
 .kiro/settings/
+
+# Projektanweisungen (Claude.ai)
+PROJEKTANWEISUNGEN.md


### PR DESCRIPTION
Lokale Projektanweisungen fuer Claude.ai vom Git-Tracking ausschliessen.