### PR TITLE
feat: batch smart republish with snapshot + recovery

### DIFF
--- a/.kiro/steering/06_Git_Workflow_Kleinanzeigen.md
+++ b/.kiro/steering/06_Git_Workflow_Kleinanzeigen.md
@@ -1,0 +1,97 @@
+---
+inclusion: always
+---
+
+# Git-Workflow: Kleinanzeigen-Spezifika
+
+Foundation und 15-Schritt-Reihenfolge stehen in der globalen `23_Git_Workflow.md`. Workspace-Spezifika in `10_Git_Workflow.md` (Arbeitsplatz). Hier nur Kleinanzeigen-Eigenheiten.
+
+## Modus
+
+**Branch-basiert.** Direkter Push auf `main` ist im Repo blockiert (Branch-Protection). Jeder Fix laeuft ueber Feature-Branch + PR + Rebase-Merge.
+
+## Sprache
+
+**Deutsch** fuer:
+- README-Release-Notes (Abschnitt "Changelog")
+- Issue-Kommentare
+- Commit-Messages-Body
+- PR-Body
+
+PR-Title und Commit-Subject in Englisch, weil Conventional Commits Standard ist.
+
+## Repository
+
+- **Repo:** `OldRon1977/Kleinanzeigen-Anzeigen-duplizieren`
+- **Main-Branch:** `main`
+- **Issue-Tracker:** GitHub Issues im selben Repo
+- **Distribution:** Userscript via Tampermonkey, der `kleinanzeigen-duplizieren.user.js` direkt vom Repo laedt
+
+## Merge-Methode
+
+Rebase-Merge via `gh pr merge --rebase --delete-branch`.
+
+## Versions-Bump (Schritt 3) -- Pflicht
+
+Pflicht im selben PR, sobald die Aenderung den User-sichtbaren Userscript-Pfad beruehrt.
+
+Folgende Stellen muessen synchron sein:
+
+1. **`package.json`** -- `version` Feld, Single Source of Truth.
+2. **`kleinanzeigen-duplizieren.user.js`** -- Userscript-Header `// @version       X.Y.Z`.
+3. **`helper.user.js`** -- nur wenn Helper aktualisiert wurde, eigener Header `// @version`.
+4. **`README.md`** -- neuer Eintrag im Abschnitt "Changelog" oberhalb des bestehenden.
+
+**Synchronisation aktuell manuell.** Geplant: Build-Script, das `@version` aus `package.json` in den Userscript-Header schreibt. Bis dahin: Pre-Commit-Sweep zwingend:
+
+```powershell
+$pkg = (Get-Content package.json -Raw | ConvertFrom-Json).version
+$uVer = (Select-String -Path "kleinanzeigen-duplizieren.user.js" -Pattern '@version\s+(\S+)').Matches.Groups[1].Value
+if ($pkg -ne $uVer) { Write-Error "Version mismatch: package.json=$pkg, user.js=$uVer" }
+```
+
+Beim Bump des Helpers analog `helper.user.js` checken.
+
+## Build (Schritt 4) -- aktuell kein Build
+
+Kein npm-Build-Script. `kleinanzeigen-duplizieren.user.js` wird manuell editiert.
+
+Geplant: Build-Script, das Header und Body synchronisiert. Wenn vorhanden, wird Schritt 4 Pflicht (`npm run build`).
+
+## Release-Notes (Schritt 6) -- Pflicht
+
+- Datei: `README.md`, Abschnitt **`## Changelog`**.
+- Sprache: Deutsch.
+- Format wie bestehende Eintraege:
+  ```
+  ### Version X.Y.Z (Monat YYYY)
+
+  - **Neu**: ...
+  - **Fix**: ...
+  - Intern: ...
+  ```
+- Neuer Eintrag oberhalb des bestehenden.
+- **Keine Issue-Refs** (globale Regel).
+
+## Issue-Kommentare (Schritte 7 und 15) -- Pflicht (wenn Issue)
+
+- Sprache: Deutsch.
+- Live-Kommentar nach Merge gemaess globaler Regel.
+- Format-Vorlage:
+  > Fix ist live in vX.Y.Z. Update via Tampermonkey oder Re-Install ueber den Userscript-Link.
+  >
+  > [Optional 2-4 Saetze ueber die Ursache.]
+- Issue wird NICHT geschlossen, nur referenziert.
+- Test-Aufforderungen an Reporter schreibt der User manuell.
+
+## Freigabe-Gate (Schritt 10) -- Pflicht
+
+User testet auf gepushtem Branch via Tampermonkey-Install der Branch-Version. Erst nach Freigabe geht die Auftragskette ab Schritt 11 los.
+
+## VERBOTEN
+
+- Direkt auf `main` committen (durch Branch-Protection ohnehin blockiert, aber explizite Regel).
+- Mergen ohne User-OK.
+- Issue automatisch schliessen.
+- Versions-Bump ohne synchronen `@version`-Header in der `.user.js`.
+- Issue-Refs in `README.md` (Changelog), Issue-Kommentaren oder Doku.

--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -10,6 +10,45 @@ Dieses Dokument dokumentiert alle Code-Quality-Verbesserungen über verschiedene
 
 ---
 
+## 🔥 v3.5.0 - Batch Smart-Republish (Mai 2026)
+
+**Änderungsdatum:** Mai 2026  
+**Typ:** Feature  
+**Quality Improvement:** Keine Score-Änderung (neues Feature)
+
+### Hinzugefügt
+
+- **Batch-Modus auf "Meine Anzeigen":** Neuer Button `⏰ Alle alten neu einstellen` über der Anzeigen-Liste.
+- **Filter:** Anzeigen werden als "älter als 7 Tage" eingestuft, wenn das Enddatum höchstens 53 Tage in der Zukunft liegt (60-Tage-Standard-Laufzeit minus 7).
+- **Confirm-Overlay:** Listet alle Treffer mit Titel, ID und Restlaufzeit. Start-/Abbrechen-Buttons.
+- **Sequenzielle Abarbeitung:** Pro Anzeige wird ein neuer Tab mit `#smartRepublish` geöffnet. Zwischen zwei Anzeigen 7 +- 2 Minuten Jitter (Math.random).
+- **Cross-Tab-Kommunikation:** über `localStorage` (Schlüssel `ka-batch-result-<adId>`). Worker schreibt `ok` oder `error:<msg>`, Orchestrator hört via `storage`-Event und Polling-Fallback.
+- **Stop-Button:** Bricht Loop nach der laufenden Anzeige ab.
+- **Skip-and-continue:** Fehlgeschlagene Anzeigen werden übersprungen, am Ende als Fehlerliste angezeigt.
+- **Versionsbump:** Hauptscript 3.4.0 → 3.5.0, Helper 1.1.2 → 1.3.0, `package.json` 3.3.11 → 3.5.0 (Drift korrigiert).
+
+### Architektur
+
+```
+Meine-Anzeigen (Helper, Orchestrator)
+   |  Queue: [adId1, adId2, ...]
+   +-- oeffnet Tab #1 mit #smartRepublish
+   |      +-- Hauptscript fuehrt smartRepublish aus,
+   |          schreibt ka-batch-result-<adId> in localStorage
+   +-- Orchestrator liest Ergebnis, schliesst Tab
+   +-- wartet 7 +- 2 min (Jitter)
+   +-- naechste adId, bis Queue leer
+```
+
+### Limitierungen
+
+- **Tab-abhängig:** Schliesst der User die "Meine Anzeigen"-Seite, bricht der Batch ab. Keine persistente Queue.
+- **Pagination:** Nur die aktuell sichtbaren Karten werden berücksichtigt. Bei vielen Anzeigen ggf. mehrfach starten.
+- **Sonder-Laufzeiten:** Filter setzt 60-Tage-Default voraus. Anzeigen mit abweichender Laufzeit können falsch eingestuft werden -- Confirm-Dialog macht es vor dem Start sichtbar.
+- **Popup-Blocker:** Browser könnte `window.open` aus Timer-Kontext blockieren. Fallback dokumentiert.
+
+---
+
 ## 🔧 v3.2.1 - Consistency Fix (März 2026)
 
 **Änderungsdatum:** März 2026

--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -10,22 +10,30 @@ Dieses Dokument dokumentiert alle Code-Quality-Verbesserungen über verschiedene
 
 ---
 
-## 🔥 v3.5.0 - Batch Smart-Republish (Mai 2026)
+## 🔥 v3.5.0 - Batch Smart-Republish + Safety-Net (Mai 2026)
 
 **Änderungsdatum:** Mai 2026  
 **Typ:** Feature  
-**Quality Improvement:** Keine Score-Änderung (neues Feature)
+**Quality Improvement:** Robustheit gegen Datenverlust deutlich erhöht
 
 ### Hinzugefügt
 
 - **Batch-Modus auf "Meine Anzeigen":** Neuer Button `⏰ Alle alten neu einstellen` über der Anzeigen-Liste.
 - **Filter:** Anzeigen werden als "älter als 7 Tage" eingestuft, wenn das Enddatum höchstens 53 Tage in der Zukunft liegt (60-Tage-Standard-Laufzeit minus 7).
 - **Confirm-Overlay:** Listet alle Treffer mit Titel, ID und Restlaufzeit. Start-/Abbrechen-Buttons.
-- **Sequenzielle Abarbeitung:** Pro Anzeige wird ein neuer Tab mit `#smartRepublish` geöffnet. Zwischen zwei Anzeigen 7 +- 2 Minuten Jitter (Math.random).
-- **Cross-Tab-Kommunikation:** über `localStorage` (Schlüssel `ka-batch-result-<adId>`). Worker schreibt `ok` oder `error:<msg>`, Orchestrator hört via `storage`-Event und Polling-Fallback.
+- **Sequenzielle Abarbeitung:** Pro Anzeige neuer Tab mit `#smartRepublish`. Zwischen zwei Anzeigen 7 ± 2 Minuten Jitter (Math.random).
+- **Cross-Tab-Kommunikation:** über `localStorage` (`ka-batch-result-<adId>`). Worker schreibt `ok` oder `error:<code>:<sub>`, Orchestrator hört via `storage`-Event und Polling-Fallback.
 - **Stop-Button:** Bricht Loop nach der laufenden Anzeige ab.
-- **Skip-and-continue:** Fehlgeschlagene Anzeigen werden übersprungen, am Ende als Fehlerliste angezeigt.
+- **Skip-and-continue** bei harmlosen Fehlern (`delete_failed`, `timeout`); fehlgeschlagene Anzeigen werden übersprungen und am Ende als Fehlerliste angezeigt.
 - **Versionsbump:** Hauptscript 3.4.0 → 3.5.0, Helper 1.1.2 → 1.3.0, `package.json` 3.3.11 → 3.5.0 (Drift korrigiert).
+
+### Safety-Net (P1 + P2 + P3)
+
+- **P1 Save-Verifikation:** Worker meldet `ok` erst, wenn die Bearbeiten-Seite verlassen wurde oder eine neue Anzeigen-ID auftaucht. Vorher wurde `ok` direkt vor dem Click geschrieben – ein vorzeitiges OK trotz fehlgeschlagenem Speichern war möglich. Jetzt nicht mehr.
+- **P2 Recovery-Snapshot:** Worker liest vor der Löschung alle Form-Felder (Titel, Beschreibung, Preis, Kategorie, Standort) plus alle Bild-URLs aus dem CDN als Bytes (`fetch` → Blob). Speichert atomar in IndexedDB (Datenbank `ka-batch`, Store `snapshots`). Bei Erfolg wird der Snapshot automatisch verworfen, bei Datenverlust bleibt er erhalten.
+- **Recovery-UI:** Helper-Overlay zeigt verbliebene Snapshots in Confirm- und Done-Phase. Button **"Als ZIP herunterladen"** baut ein selbst-erzeugtes ZIP-Archiv (STORE-only, kein Fremdcode) mit `data.json` + Bildern pro Anzeige. Button **"Alle löschen"** mit Bestätigung. Snapshots bleiben so lange persistent, bis User sie löscht.
+- **P3 Auto-Stop bei Datenverlust:** Worker differenziert Fehler-Codes: `delete_failed` (Original noch da, harmlos) vs. `save_failed:delete_ok` (Original weg, neue Anzeige nicht entstanden, Datenverlust). Bei `save_failed:delete_ok` stoppt der Helper die Schleife sofort. Begrenzt den Schaden auf maximal eine Anzeige.
+- **Timeout-Bump:** Worker-Result-Timeout von 90s auf 180s erhöht. Bilder-Verarbeitung beim Snapshot-Erstellen kostet einige Sekunden, plus Server-Roundtrip.
 
 ### Architektur
 
@@ -33,19 +41,37 @@ Dieses Dokument dokumentiert alle Code-Quality-Verbesserungen über verschiedene
 Meine-Anzeigen (Helper, Orchestrator)
    |  Queue: [adId1, adId2, ...]
    +-- oeffnet Tab #1 mit #smartRepublish
-   |      +-- Hauptscript fuehrt smartRepublish aus,
-   |          schreibt ka-batch-result-<adId> in localStorage
+   |      +-- Hauptscript: Snapshot in IndexedDB
+   |      +-- Hauptscript: deleteAd()
+   |      +-- Hauptscript: saveBtn.click()
+   |      +-- Hauptscript: waitForSaveSuccess() (Navigation oder neue adId)
+   |      +-- Hauptscript: ka-batch-result-<adId> = 'ok' | 'error:<code>'
    +-- Orchestrator liest Ergebnis, schliesst Tab
+   +-- Snapshot loeschen wenn ok oder harmloser Fehler
+   +-- Snapshot behalten + STOP wenn dataLoss
    +-- wartet 7 +- 2 min (Jitter)
    +-- naechste adId, bis Queue leer
 ```
 
+### Fehler-Codes (Worker -> Helper)
+
+| Code | Bedeutung | dataLoss | Helper-Verhalten |
+|---|---|---|---|
+| `ok` | Save verifiziert | nein | Snapshot loeschen, weiter |
+| `error:snapshot_failed:<msg>` | Snapshot-Erstellung scheiterte vor Loeschung | nein | weiter (kein Datenverlust, weil Loeschung nicht ausgefuehrt) |
+| `error:delete_failed` | Loeschung des Originals scheiterte | nein | Snapshot loeschen, weiter |
+| `error:save_failed:delete_ok` | Original geloescht, neue Anzeige nicht entstand | **ja** | **Auto-Stop**, Snapshot bleibt |
+| `error:save_failed:delete_failed` | Loeschung scheiterte UND Save scheiterte | nein | weiter |
+| `error:exception:<msg>` | Unerwartete Exception | unklar | weiter (konservativ; Snapshot bleibt nicht) |
+| `error:timeout` | Worker hat 180s nicht geantwortet | unklar | weiter |
+
 ### Limitierungen
 
-- **Tab-abhängig:** Schliesst der User die "Meine Anzeigen"-Seite, bricht der Batch ab. Keine persistente Queue.
+- **Tab-abhängig:** Schliesst der User die "Meine Anzeigen"-Seite, bricht der Batch ab. Snapshots bleiben in IndexedDB erhalten.
 - **Pagination:** Nur die aktuell sichtbaren Karten werden berücksichtigt. Bei vielen Anzeigen ggf. mehrfach starten.
-- **Sonder-Laufzeiten:** Filter setzt 60-Tage-Default voraus. Anzeigen mit abweichender Laufzeit können falsch eingestuft werden -- Confirm-Dialog macht es vor dem Start sichtbar.
-- **Popup-Blocker:** Browser könnte `window.open` aus Timer-Kontext blockieren. Fallback dokumentiert.
+- **Sonder-Laufzeiten:** Filter setzt 60-Tage-Default voraus.
+- **Popup-Blocker:** Browser könnte `window.open` aus Timer-Kontext blockieren.
+- **Bild-Download:** Wenn Kleinanzeigen ein Bild hinter dem CDN nicht ausliefert, wird für dieses Bild nur die URL gespeichert, nicht der Blob. Im Recovery-ZIP fehlt es dann.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Kein manuelles Wegklicken mehr nötig.
 ## Technische Details
 
 ### Berechtigungen
-Beide Scripts verwenden `@grant none` - keine erweiterten Tampermonkey-Berechtigungen. Sie kommunizieren ausschließlich mit kleinanzeigen.de über HTTPS.
+Hauptscript verwendet `@grant none`. Helper-Script verwendet ab v1.3.0 `@grant GM_openInTab` für das robuste Schließen von Worker-Tabs im Batch-Modus -- ohne diese Berechtigung kann ein Userscript Tabs nach einer Navigation nicht mehr zuverlässig schließen. Beide Scripts kommunizieren ausschließlich mit kleinanzeigen.de über HTTPS.
 
 ### Unterstützte URLs
 - `https://www.kleinanzeigen.de/p-anzeige-bearbeiten.html*` (Hauptscript)
@@ -92,14 +92,14 @@ Beide Scripts verwenden `@grant none` - keine erweiterten Tampermonkey-Berechtig
 ## Changelog
 
 ### Version 3.5.0 / Helper 1.3.0 (Mai 2026)
-- **Neu**: Batch-Modus auf "Meine Anzeigen". Ein Button stellt alle Anzeigen, die älter als 7 Tage sind, nacheinander mit 7 ± 2 Minuten Pause neu ein.
+- **Neu**: Batch-Modus auf "Meine Anzeigen". Ein Button stellt alle Anzeigen, die älter als 7 Tage sind, nacheinander mit 3 ± 1 Minuten Pause neu ein.
 - **Neu**: Recovery-Snapshot vor jedem Smart-Republish im Batch. Texte, Felder und Bilder werden lokal in IndexedDB gespeichert, bei erfolgreicher Neu-Anzeige automatisch verworfen.
 - **Neu**: Save-Verifikation. Erfolg wird erst gemeldet, wenn die Bearbeiten-Seite verlassen wurde oder eine neue Anzeigen-ID auftaucht. Kein vorzeitiges OK.
 - **Neu**: Auto-Stop bei Datenverlust. Wenn Original gelöscht ist, neue Anzeige aber nicht entstand, bricht der Batch sofort ab und hält den Snapshot.
 - **Neu**: Recovery-UI im Done- und Confirm-Overlay. Verbliebene Snapshots lassen sich als ZIP herunterladen (`data.json` plus Bilder pro Anzeige) oder löschen.
 - **Neu**: Kleines Overlay zeigt Trefferliste, Start-/Abbrechen-Buttons, Fortschritt und Stop-Button.
 - Worker-Timeout von 90 auf 180 Sekunden erhöht (gibt Bilder-Verarbeitung mehr Luft).
-- Tab-übergreifende Kommunikation über `localStorage` (Result-Signal) und IndexedDB (Snapshot). Weiterhin `@grant none`.
+- Tab-übergreifende Kommunikation über `localStorage` (Result-Signal) und IndexedDB (Snapshot). Helper nutzt jetzt `GM_openInTab`, um Worker-Tabs nach Erfolg zuverlässig zu schließen. Hauptscript bleibt `@grant none`.
 - Helper 1.3.0 bringt Orchestrator und Recovery-UI. Hauptscript 3.5.0 ergänzt Snapshot-Erstellung, Save-Verifikation und differenzierte Fehler-Codes.
 - Intern: `package.json`-Version (3.3.11 → 3.5.0) an Userscript-Header angeglichen.
 

--- a/README.md
+++ b/README.md
@@ -91,11 +91,17 @@ Beide Scripts verwenden `@grant none` - keine erweiterten Tampermonkey-Berechtig
 
 ## Changelog
 
+### Version 3.5.0 / Helper 1.3.0 (Mai 2026)
+- **Neu**: Batch-Modus auf "Meine Anzeigen". Ein Button stellt alle Anzeigen, die älter als 7 Tage sind, nacheinander mit 7 ± 2 Minuten Pause neu ein.
+- **Neu**: Kleines Overlay zeigt Trefferliste, Start-/Abbrechen-Buttons, Fortschritt und Stop-Button.
+- Tab-übergreifende Kommunikation über `localStorage` (kein zusätzliches `@grant`).
+- Helper 1.3.0 bringt den Orchestrator. Hauptscript 3.5.0 ergänzt einen Result-Hook in `smartRepublish`.
+- Intern: `package.json`-Version (3.3.11 → 3.5.0) an Userscript-Header angeglichen.
+
 ### Version 3.4.0 (April 2026)
 - **Neu**: Banner-Blocker blendet kostenpflichtige Feature-Optionen per CSS aus
 - **Neu**: Info-Banner ("Bearbeiten schiebt nicht hoch") wird ausgeblendet
 - **Neu**: Popup-Dismisser klickt Upsell-Dialoge automatisch weg ("Ohne Hochschieben weiter", etc.)
-- Fix für Issue #29: Neuer Banner blockierte Skript-Funktionalität
 
 ### Version 3.3.11 / Helper 1.1.2 (April 2026)
 - Hauptscript 3.3.9-3.3.11: Bugfixes (React-Render, adId-Handling, doppeltes if)

--- a/README.md
+++ b/README.md
@@ -93,9 +93,14 @@ Beide Scripts verwenden `@grant none` - keine erweiterten Tampermonkey-Berechtig
 
 ### Version 3.5.0 / Helper 1.3.0 (Mai 2026)
 - **Neu**: Batch-Modus auf "Meine Anzeigen". Ein Button stellt alle Anzeigen, die älter als 7 Tage sind, nacheinander mit 7 ± 2 Minuten Pause neu ein.
+- **Neu**: Recovery-Snapshot vor jedem Smart-Republish im Batch. Texte, Felder und Bilder werden lokal in IndexedDB gespeichert, bei erfolgreicher Neu-Anzeige automatisch verworfen.
+- **Neu**: Save-Verifikation. Erfolg wird erst gemeldet, wenn die Bearbeiten-Seite verlassen wurde oder eine neue Anzeigen-ID auftaucht. Kein vorzeitiges OK.
+- **Neu**: Auto-Stop bei Datenverlust. Wenn Original gelöscht ist, neue Anzeige aber nicht entstand, bricht der Batch sofort ab und hält den Snapshot.
+- **Neu**: Recovery-UI im Done- und Confirm-Overlay. Verbliebene Snapshots lassen sich als ZIP herunterladen (`data.json` plus Bilder pro Anzeige) oder löschen.
 - **Neu**: Kleines Overlay zeigt Trefferliste, Start-/Abbrechen-Buttons, Fortschritt und Stop-Button.
-- Tab-übergreifende Kommunikation über `localStorage` (kein zusätzliches `@grant`).
-- Helper 1.3.0 bringt den Orchestrator. Hauptscript 3.5.0 ergänzt einen Result-Hook in `smartRepublish`.
+- Worker-Timeout von 90 auf 180 Sekunden erhöht (gibt Bilder-Verarbeitung mehr Luft).
+- Tab-übergreifende Kommunikation über `localStorage` (Result-Signal) und IndexedDB (Snapshot). Weiterhin `@grant none`.
+- Helper 1.3.0 bringt Orchestrator und Recovery-UI. Hauptscript 3.5.0 ergänzt Snapshot-Erstellung, Save-Verifikation und differenzierte Fehler-Codes.
 - Intern: `package.json`-Version (3.3.11 → 3.5.0) an Userscript-Header angeglichen.
 
 ### Version 3.4.0 (April 2026)

--- a/helper.user.js
+++ b/helper.user.js
@@ -726,6 +726,7 @@
                 tabHandle = { close: function () { try { w.close(); } catch (e) {} }, get closed() { return w.closed; } };
             }
 
+            let done = false;
             const cleanup = function (closeTab) {
                 window.removeEventListener('storage', onStorage);
                 clearTimeout(timeoutId);
@@ -737,6 +738,8 @@
             };
 
             const finish = function (payload) {
+                if (done) return;
+                done = true;
                 cleanup(payload.keepTab !== true);
                 resolve(payload);
             };

--- a/helper.user.js
+++ b/helper.user.js
@@ -292,12 +292,26 @@
     }
 
     function openSmartRepublish(adId, button) {
-        window.open(
-            'https://www.kleinanzeigen.de/p-anzeige-bearbeiten.html?adId=' + adId + '#smartRepublish',
-            '_blank'
-        );
-        button.style.color = 'red';
-        button.textContent = '\u2705 Geöffnet';
+        button.disabled = true;
+        button.style.color = '#888';
+        button.textContent = '\u23F3 Laeuft \u2026';
+        processOne({ adId: adId, title: '' }).then(function (res) {
+            if (res.ok) {
+                button.style.color = '#27ae60';
+                button.textContent = '\u2705 Fertig';
+                deleteSnapshot(adId).catch(function () {});
+            } else {
+                button.style.color = '#e74c3c';
+                button.textContent = '\u274C ' + (res.code || 'Fehler');
+                button.title = res.error || 'unbekannter Fehler';
+                button.disabled = false;
+            }
+        }, function (err) {
+            warn('Single-Republish unerwartet abgebrochen', err);
+            button.style.color = '#e74c3c';
+            button.textContent = '\u274C Abbruch';
+            button.disabled = false;
+        });
     }
 
     // === GLOBALER BATCH-TRIGGER-BUTTON ===

--- a/helper.user.js
+++ b/helper.user.js
@@ -14,7 +14,7 @@
 // @updateURL     https://github.com/OldRon1977/Kleinanzeigen-Anzeigen-duplizieren/raw/main/helper.user.js
 // @downloadURL   https://github.com/OldRon1977/Kleinanzeigen-Anzeigen-duplizieren/raw/main/helper.user.js
 // @run-at        document-idle
-// @grant         none
+// @grant         GM_openInTab
 // ==/UserScript==
 
 (function () {
@@ -26,9 +26,9 @@
     // in der Zukunft liegt.
     const MIN_DAYS_TO_END = 53;
 
-    // Jitter-Delay zwischen zwei Smart-Republish-Vorgaengen: 7 +- 2 Minuten.
-    const DELAY_BASE_MS = 7 * 60 * 1000;
-    const DELAY_JITTER_MS = 2 * 60 * 1000;
+    // Jitter-Delay zwischen zwei Smart-Republish-Vorgaengen: 3 +- 1 Minuten.
+    const DELAY_BASE_MS = 3 * 60 * 1000;
+    const DELAY_JITTER_MS = 1 * 60 * 1000;
 
     // Maximaler Wartepuffer auf das Result-Signal aus dem Worker-Tab.
     // Nach Saving kann Bilder-Verarbeitung lange dauern; 180s ist grosszuegig.
@@ -493,7 +493,7 @@
         summary.appendChild(line1);
         const line2 = document.createElement('div');
         line2.style.cssText = 'color:#666;margin-top:4px;';
-        line2.textContent = 'Geschätzte Laufzeit: ca. ' + minutes + ' Minuten (7 ± 2 min Pause pro Anzeige).';
+        line2.textContent = 'Geschätzte Laufzeit: ca. ' + minutes + ' Minuten (3 ± 1 min Pause pro Anzeige).';
         summary.appendChild(line2);
         overlay.appendChild(summary);
 
@@ -684,22 +684,40 @@
             try { localStorage.removeItem(lsKey); } catch (e) {}
 
             log('Öffne Tab für adId ' + adId);
-            const tabRef = window.open(
-                'https://www.kleinanzeigen.de/p-anzeige-bearbeiten.html?adId=' + adId + '#smartRepublish',
-                '_blank'
-            );
-            if (!tabRef) {
-                resolve({ ok: false, error: 'Popup blockiert', code: 'popup_blocked', keepTab: false });
-                return;
+            // GM_openInTab gibt ein Handle mit close()/closed/onclose zurueck,
+            // das auch nach Navigation des Tabs weiter funktioniert.
+            // Fallback auf window.open, falls @grant aus irgendeinem Grund fehlt.
+            let tabHandle = null;
+            try {
+                if (typeof GM_openInTab === 'function') {
+                    tabHandle = GM_openInTab(
+                        'https://www.kleinanzeigen.de/p-anzeige-bearbeiten.html?adId=' + adId + '#smartRepublish',
+                        { active: true, insert: true, setParent: true }
+                    );
+                }
+            } catch (e) {
+                warn('GM_openInTab fehlgeschlagen, fallback auf window.open', e);
+            }
+            if (!tabHandle) {
+                const w = window.open(
+                    'https://www.kleinanzeigen.de/p-anzeige-bearbeiten.html?adId=' + adId + '#smartRepublish',
+                    '_blank'
+                );
+                if (!w) {
+                    resolve({ ok: false, error: 'Popup blockiert', code: 'popup_blocked' });
+                    return;
+                }
+                // Pseudo-Handle, das nicht zuverlaessig schliesst -- aber das ist
+                // der Fallback, kein Default.
+                tabHandle = { close: function () { try { w.close(); } catch (e) {} }, get closed() { return w.closed; } };
             }
 
             const cleanup = function (closeTab) {
                 window.removeEventListener('storage', onStorage);
                 clearTimeout(timeoutId);
                 clearInterval(pollId);
-                if (saveVerifyTimer) clearTimeout(saveVerifyTimer);
                 if (closeTab) {
-                    try { tabRef.close(); } catch (e) {}
+                    try { tabHandle.close(); } catch (e) {}
                 }
                 try { localStorage.removeItem(lsKey); } catch (e) {}
             };
@@ -709,86 +727,10 @@
                 resolve(payload);
             };
 
-            // Save-Verifikation: Worker schreibt 'save_clicked:<deleteState>'
-            // bevor er den Click absendet. Wir uebernehmen ab dort die
-            // URL-Beobachtung des Worker-Tabs, weil dessen JS-Context bei
-            // Navigation stirbt.
-            let saveVerifyTimer = null;
-            const SAVE_VERIFY_TIMEOUT_MS = 60 * 1000;
-            const SAVE_VERIFY_POLL_MS = 1000;
-
-            const startSaveVerify = function (deleteState) {
-                const verifyStart = Date.now();
-                const verifyTick = function () {
-                    if (tabRef.closed) {
-                        // Tab ist weg. Wenn der Worker auf der Bestaetigungs-Seite
-                        // selbst 'ok' ins localStorage geschrieben hat, wird der
-                        // storage-Event-Listener das gleich verarbeiten. Hier nur
-                        // dann 'save_aborted' melden, wenn nichts mehr eintrudelt.
-                        let okFlag = null;
-                        try { okFlag = localStorage.getItem(lsKey); } catch (e) {}
-                        if (okFlag === 'ok') {
-                            finish({ ok: true });
-                            return;
-                        }
-                        // Kurz warten, dann final entscheiden -- gibt dem
-                        // storage-Event etwas Luft, den Listener zu erreichen.
-                        setTimeout(function () {
-                            let late = null;
-                            try { late = localStorage.getItem(lsKey); } catch (e) {}
-                            if (late === 'ok') {
-                                finish({ ok: true });
-                            } else {
-                                finish({
-                                    ok: false,
-                                    error: 'save_aborted',
-                                    code: 'save_aborted',
-                                    dataLoss: deleteState === 'delete_ok',
-                                    keepTab: deleteState === 'delete_ok'
-                                });
-                            }
-                        }, 1500);
-                        return;
-                    }
-                    let href = '';
-                    try { href = tabRef.location.href || ''; } catch (e) {
-                        // Cross-Origin-Block (sollte same-origin nicht passieren) -> retry
-                    }
-                    if (href.indexOf('/p-anzeige-aufgeben-bestaetigung.html') >= 0) {
-                        finish({ ok: true });
-                        return;
-                    }
-                    if (Date.now() - verifyStart >= SAVE_VERIFY_TIMEOUT_MS) {
-                        finish({
-                            ok: false,
-                            error: 'save_failed:' + deleteState,
-                            code: 'save_failed',
-                            dataLoss: deleteState === 'delete_ok',
-                            keepTab: deleteState === 'delete_ok'
-                        });
-                        return;
-                    }
-                    saveVerifyTimer = setTimeout(verifyTick, SAVE_VERIFY_POLL_MS);
-                };
-                verifyTick();
-            };
-
             const handleValue = function (raw) {
                 if (!raw) return false;
                 if (raw === 'ok') {
                     finish({ ok: true });
-                    return true;
-                }
-                if (raw.indexOf('save_clicked:') === 0) {
-                    // Save abgesendet. URL-Polling im Helper-Tab uebernimmt ab hier.
-                    // Wir merken uns, dass der Click-Marker schon verarbeitet wurde,
-                    // damit pollId nicht endlos triggert. Aber: Result-Key NICHT loeschen,
-                    // weil der Worker auf der Bestaetigungs-Seite gleich 'ok' reinschreibt.
-                    if (saveVerifyTimer === 'pending' || saveVerifyTimer) return true;
-                    saveVerifyTimer = 'pending';
-                    const deleteState = raw.split(':')[1] || 'delete_ok';
-                    log('Save abgesendet (' + deleteState + '), starte URL-Verifikation');
-                    startSaveVerify(deleteState);
                     return true;
                 }
                 if (raw.indexOf('error:') === 0) {

--- a/helper.user.js
+++ b/helper.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name          eBay Kleinanzeigen - neu einstellen helper
 // @namespace     https://github.com/OldRon1977/Kleinanzeigen-Anzeigen-duplizieren
-// @description   Hilfsskript fuer Smart Neu-Einstellen direkt aus "Meine Anzeigen", inkl. Batch-Modus
+// @description   Hilfsskript fuer Smart Neu-Einstellen direkt aus "Meine Anzeigen", inkl. Batch-Modus und Recovery-Snapshot
 // @icon          https://www.kleinanzeigen.de/favicon.ico
 // @copyright     2026
 // @license       MIT
@@ -22,7 +22,7 @@
 
     // === KONSTANTEN ===
     // Default Anzeigenlaufzeit auf Kleinanzeigen = 60 Tage. Eine Anzeige gilt
-    // als "älter als 7 Tage", wenn das Enddatum höchstens (60 - 7) = 53 Tage
+    // als "aelter als 7 Tage", wenn das Enddatum hoechstens (60 - 7) = 53 Tage
     // in der Zukunft liegt.
     const MIN_DAYS_TO_END = 53;
 
@@ -31,20 +31,240 @@
     const DELAY_JITTER_MS = 2 * 60 * 1000;
 
     // Maximaler Wartepuffer auf das Result-Signal aus dem Worker-Tab.
-    const RESULT_WAIT_TIMEOUT_MS = 90 * 1000;
+    // Nach Saving kann Bilder-Verarbeitung lange dauern; 180s ist grosszuegig.
+    const RESULT_WAIT_TIMEOUT_MS = 180 * 1000;
 
-    // localStorage-Schlüssel
+    // localStorage-Schluessel
     const LS_RESULT_PREFIX = 'ka-batch-result-';
+
+    // IndexedDB
+    const IDB_NAME = 'ka-batch';
+    const IDB_VERSION = 1;
+    const IDB_STORE = 'snapshots';
 
     const MARKER = 'data-ka-smart-helper';
     const TRIGGER_BTN_ID = 'ka-batch-trigger';
     const OVERLAY_ID = 'ka-batch-overlay';
 
-    // === LOGGING ===
     const log = (msg, data) => console.log('[KA-Helper] ' + msg, data || '');
     const warn = (msg, data) => console.warn('[KA-Helper] ' + msg, data || '');
 
-    // === EINZEL-BUTTON PRO ANZEIGE (bestehende Funktion) ===
+    // === INDEXEDDB-WRAPPER ===
+    function openIDB() {
+        return new Promise(function (resolve, reject) {
+            const req = indexedDB.open(IDB_NAME, IDB_VERSION);
+            req.onupgradeneeded = function () {
+                const db = req.result;
+                if (!db.objectStoreNames.contains(IDB_STORE)) {
+                    db.createObjectStore(IDB_STORE, { keyPath: 'adId' });
+                }
+            };
+            req.onsuccess = function () { resolve(req.result); };
+            req.onerror = function () { reject(req.error); };
+        });
+    }
+    async function listSnapshotMeta() {
+        const db = await openIDB();
+        return new Promise(function (resolve, reject) {
+            const tx = db.transaction(IDB_STORE, 'readonly');
+            const store = tx.objectStore(IDB_STORE);
+            const req = store.getAll();
+            req.onsuccess = function () {
+                const all = req.result || [];
+                const meta = all.map(function (s) {
+                    return {
+                        adId: s.adId,
+                        title: s.title || '(ohne Titel)',
+                        capturedAt: s.capturedAt,
+                        imageCount: (s.images || []).length
+                    };
+                });
+                resolve(meta);
+            };
+            req.onerror = function () { reject(req.error); };
+        });
+    }
+    async function getSnapshotsAll() {
+        const db = await openIDB();
+        return new Promise(function (resolve, reject) {
+            const tx = db.transaction(IDB_STORE, 'readonly');
+            const store = tx.objectStore(IDB_STORE);
+            const req = store.getAll();
+            req.onsuccess = function () { resolve(req.result || []); };
+            req.onerror = function () { reject(req.error); };
+        });
+    }
+    async function deleteSnapshot(adId) {
+        const db = await openIDB();
+        return new Promise(function (resolve, reject) {
+            const tx = db.transaction(IDB_STORE, 'readwrite');
+            const store = tx.objectStore(IDB_STORE);
+            const req = store.delete(adId);
+            req.onsuccess = function () { resolve(); };
+            req.onerror = function () { reject(req.error); };
+        });
+    }
+    async function clearAllSnapshots() {
+        const db = await openIDB();
+        return new Promise(function (resolve, reject) {
+            const tx = db.transaction(IDB_STORE, 'readwrite');
+            const store = tx.objectStore(IDB_STORE);
+            const req = store.clear();
+            req.onsuccess = function () { resolve(); };
+            req.onerror = function () { reject(req.error); };
+        });
+    }
+
+    // === ZIP (STORE-only, kein Fremdcode) ===
+    let CRC_TABLE = null;
+    function makeCrcTable() {
+        const t = new Uint32Array(256);
+        for (let n = 0; n < 256; n++) {
+            let c = n;
+            for (let k = 0; k < 8; k++) {
+                c = (c & 1) ? (0xEDB88320 ^ (c >>> 1)) : (c >>> 1);
+            }
+            t[n] = c >>> 0;
+        }
+        return t;
+    }
+    function crc32(uint8) {
+        if (!CRC_TABLE) CRC_TABLE = makeCrcTable();
+        let crc = 0xFFFFFFFF;
+        for (let i = 0; i < uint8.length; i++) {
+            crc = (CRC_TABLE[(crc ^ uint8[i]) & 0xFF] ^ (crc >>> 8)) >>> 0;
+        }
+        return (crc ^ 0xFFFFFFFF) >>> 0;
+    }
+    function utf8(str) { return new TextEncoder().encode(str); }
+    function dosTime(date) {
+        const t = ((date.getHours() & 0x1F) << 11) | ((date.getMinutes() & 0x3F) << 5) | ((date.getSeconds() / 2) & 0x1F);
+        const d = (((date.getFullYear() - 1980) & 0x7F) << 9) | (((date.getMonth() + 1) & 0xF) << 5) | (date.getDate() & 0x1F);
+        return { t: t & 0xFFFF, d: d & 0xFFFF };
+    }
+    /**
+     * files: [{ name: string, data: Uint8Array }]
+     * Returns Blob (application/zip)
+     */
+    async function buildZip(files) {
+        const now = new Date();
+        const dt = dosTime(now);
+        const localParts = [];
+        const centralParts = [];
+        let offset = 0;
+
+        for (const f of files) {
+            const nameBytes = utf8(f.name);
+            const crc = crc32(f.data);
+            const size = f.data.length;
+
+            // Local file header
+            const lfh = new Uint8Array(30 + nameBytes.length);
+            const dv = new DataView(lfh.buffer);
+            dv.setUint32(0, 0x04034b50, true);  // signature
+            dv.setUint16(4, 20, true);           // version
+            dv.setUint16(6, 0x0800, true);       // flags (UTF-8)
+            dv.setUint16(8, 0, true);            // compression: STORE
+            dv.setUint16(10, dt.t, true);
+            dv.setUint16(12, dt.d, true);
+            dv.setUint32(14, crc, true);
+            dv.setUint32(18, size, true);
+            dv.setUint32(22, size, true);
+            dv.setUint16(26, nameBytes.length, true);
+            dv.setUint16(28, 0, true);
+            lfh.set(nameBytes, 30);
+
+            localParts.push(lfh);
+            localParts.push(f.data);
+
+            // Central directory entry
+            const cdh = new Uint8Array(46 + nameBytes.length);
+            const cdv = new DataView(cdh.buffer);
+            cdv.setUint32(0, 0x02014b50, true);
+            cdv.setUint16(4, 20, true);
+            cdv.setUint16(6, 20, true);
+            cdv.setUint16(8, 0x0800, true);
+            cdv.setUint16(10, 0, true);
+            cdv.setUint16(12, dt.t, true);
+            cdv.setUint16(14, dt.d, true);
+            cdv.setUint32(16, crc, true);
+            cdv.setUint32(20, size, true);
+            cdv.setUint32(24, size, true);
+            cdv.setUint16(28, nameBytes.length, true);
+            cdv.setUint16(30, 0, true);
+            cdv.setUint16(32, 0, true);
+            cdv.setUint16(34, 0, true);
+            cdv.setUint16(36, 0, true);
+            cdv.setUint32(38, 0, true);
+            cdv.setUint32(42, offset, true);
+            cdh.set(nameBytes, 46);
+            centralParts.push(cdh);
+
+            offset += lfh.length + size;
+        }
+
+        // Central dir size + offset
+        let cdSize = 0;
+        for (const p of centralParts) cdSize += p.length;
+        const cdOffset = offset;
+
+        // EOCD
+        const eocd = new Uint8Array(22);
+        const ev = new DataView(eocd.buffer);
+        ev.setUint32(0, 0x06054b50, true);
+        ev.setUint16(4, 0, true);
+        ev.setUint16(6, 0, true);
+        ev.setUint16(8, files.length, true);
+        ev.setUint16(10, files.length, true);
+        ev.setUint32(12, cdSize, true);
+        ev.setUint32(16, cdOffset, true);
+        ev.setUint16(20, 0, true);
+
+        return new Blob([...localParts, ...centralParts, eocd], { type: 'application/zip' });
+    }
+
+    function sanitize(str) {
+        return String(str || '').replace(/[\\\/:*?"<>|]/g, '_').replace(/\s+/g, '_').slice(0, 60);
+    }
+
+    async function downloadRecoveryZip() {
+        const snaps = await getSnapshotsAll();
+        if (!snaps.length) return;
+        const files = [];
+        for (const s of snaps) {
+            const folder = s.adId + '-' + sanitize(s.title || 'untitled') + '/';
+            const meta = {
+                adId: s.adId,
+                capturedAt: new Date(s.capturedAt || Date.now()).toISOString(),
+                title: s.title,
+                fields: s.fields || {},
+                rawFields: s.rawFields || {},
+                imageUrls: (s.images || []).map(function (i) { return i.url; })
+            };
+            files.push({ name: folder + 'data.json', data: utf8(JSON.stringify(meta, null, 2)) });
+            const imgs = s.images || [];
+            for (let i = 0; i < imgs.length; i++) {
+                const img = imgs[i];
+                if (!img.blob) continue;
+                const buf = new Uint8Array(await img.blob.arrayBuffer());
+                const ext = (img.mime && img.mime.indexOf('png') >= 0) ? 'png' : 'jpg';
+                const idx = String(i + 1).padStart(2, '0');
+                files.push({ name: folder + 'image_' + idx + '.' + ext, data: buf });
+            }
+        }
+        const zip = await buildZip(files);
+        const url = URL.createObjectURL(zip);
+        const a = document.createElement('a');
+        const ts = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
+        a.href = url;
+        a.download = 'ka-recovery-' + ts + '.zip';
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
+        setTimeout(function () { URL.revokeObjectURL(url); }, 1000);
+    }
+
+    // === EINZEL-BUTTON PRO ANZEIGE ===
     function addControlButtons() {
         const elements = document.querySelectorAll('a[href*="/p-anzeige-bearbeiten.html?adId="]');
         elements.forEach(function (element) {
@@ -111,7 +331,7 @@
         list.parentElement.insertBefore(btn, list);
     }
 
-    // === KARTEN AUSWÄHLEN ===
+    // === KARTEN AUSWAEHLEN ===
     function parseEndDate(dateStr) {
         const m = (dateStr || '').match(/^(\d{1,2})\.(\d{1,2})\.(\d{4})$/);
         if (!m) return null;
@@ -161,20 +381,12 @@
         overlay = document.createElement('div');
         overlay.id = OVERLAY_ID;
         overlay.style.cssText = [
-            'position: fixed',
-            'top: 20px',
-            'right: 20px',
-            'width: 360px',
-            'max-height: 70vh',
-            'overflow-y: auto',
-            'background: #fff',
-            'border: 1px solid #d0d0d0',
-            'border-radius: 8px',
-            'box-shadow: 0 6px 24px rgba(0,0,0,0.18)',
-            'z-index: 100000',
-            'font-family: system-ui, sans-serif',
-            'font-size: 13px',
-            'color: #222'
+            'position: fixed', 'top: 20px', 'right: 20px',
+            'width: 380px', 'max-height: 80vh', 'overflow-y: auto',
+            'background: #fff', 'border: 1px solid #d0d0d0',
+            'border-radius: 8px', 'box-shadow: 0 6px 24px rgba(0,0,0,0.18)',
+            'z-index: 100000', 'font-family: system-ui, sans-serif',
+            'font-size: 13px', 'color: #222'
         ].join(';');
         document.body.appendChild(overlay);
         return overlay;
@@ -185,16 +397,63 @@
         if (overlay) overlay.remove();
     }
 
-    function escapeHtml(s) {
-        return String(s)
-            .replace(/&/g, '&amp;')
-            .replace(/</g, '&lt;')
-            .replace(/>/g, '&gt;')
-            .replace(/"/g, '&quot;')
-            .replace(/'/g, '&#39;');
+    function makeButton(label, primary) {
+        const b = document.createElement('button');
+        b.type = 'button';
+        b.textContent = label;
+        b.style.cssText = primary
+            ? 'padding:6px 14px;border:1px solid #007bff;border-radius:4px;background:#007bff;color:#fff;cursor:pointer;font-weight:600;'
+            : 'padding:6px 14px;border:1px solid #ccc;border-radius:4px;background:#f5f5f5;cursor:pointer;';
+        return b;
     }
 
-    function renderConfirm(matches, skipped, onStart) {
+    async function appendRecoverySection(parent, snapsMeta) {
+        if (!snapsMeta.length) return;
+        const sec = document.createElement('div');
+        sec.style.cssText = 'padding:10px 14px;border-top:1px solid #eee;background:#fff7e6;';
+        const title = document.createElement('div');
+        title.style.cssText = 'font-weight:600;color:#a06200;margin-bottom:6px;';
+        title.textContent = '\u26A0 ' + snapsMeta.length + ' Recovery-Snapshot(s) verfügbar';
+        sec.appendChild(title);
+
+        const ul = document.createElement('ul');
+        ul.style.cssText = 'margin:4px 0 8px 18px;font-size:12px;color:#555;';
+        snapsMeta.forEach(function (s) {
+            const li = document.createElement('li');
+            const dt = new Date(s.capturedAt || Date.now());
+            li.textContent = (s.title || '(ohne Titel)') + ' (ID ' + s.adId + ', ' + s.imageCount + ' Bilder, ' + dt.toLocaleString() + ')';
+            ul.appendChild(li);
+        });
+        sec.appendChild(ul);
+
+        const row = document.createElement('div');
+        row.style.cssText = 'display:flex;gap:8px;';
+        const dl = makeButton('Als ZIP herunterladen', true);
+        dl.onclick = async function () {
+            dl.disabled = true;
+            dl.textContent = 'Erzeuge ZIP \u2026';
+            try {
+                await downloadRecoveryZip();
+                dl.textContent = '\u2713 ZIP heruntergeladen';
+            } catch (e) {
+                warn('ZIP-Download fehlgeschlagen', e);
+                dl.textContent = 'Fehler';
+            }
+        };
+        const clr = makeButton('Alle löschen', false);
+        clr.onclick = async function () {
+            if (!confirm('Alle ' + snapsMeta.length + ' Snapshots wirklich löschen?')) return;
+            await clearAllSnapshots();
+            sec.remove();
+        };
+        row.appendChild(dl);
+        row.appendChild(clr);
+        sec.appendChild(row);
+
+        parent.appendChild(sec);
+    }
+
+    async function renderConfirm(matches, skipped, onStart) {
         const overlay = ensureOverlay();
         const totalMs = matches.length * (DELAY_BASE_MS);
         const minutes = Math.round(totalMs / 60000);
@@ -219,6 +478,11 @@
         if (matches.length === 0) {
             summary.textContent = 'Keine Anzeigen älter als 7 Tage gefunden.';
             overlay.appendChild(summary);
+            // Trotzdem Recovery-Section anzeigen, falls Snapshots da sind
+            try {
+                const meta = await listSnapshotMeta();
+                await appendRecoverySection(overlay, meta);
+            } catch (e) { warn('Recovery-Listing fehlgeschlagen', e); }
             return;
         }
         const line1 = document.createElement('div');
@@ -257,20 +521,18 @@
             overlay.appendChild(sk);
         }
 
+        // Recovery-Section vor dem Action-Footer
+        try {
+            const meta = await listSnapshotMeta();
+            await appendRecoverySection(overlay, meta);
+        } catch (e) { warn('Recovery-Listing fehlgeschlagen', e); }
+
         const actions = document.createElement('div');
         actions.style.cssText = 'padding:10px 14px;border-top:1px solid #eee;display:flex;gap:8px;justify-content:flex-end;';
-        const cancel = document.createElement('button');
-        cancel.type = 'button';
-        cancel.textContent = 'Abbrechen';
-        cancel.style.cssText = 'padding:6px 14px;border:1px solid #ccc;border-radius:4px;background:#f5f5f5;cursor:pointer;';
+        const cancel = makeButton('Abbrechen', false);
         cancel.onclick = closeOverlay;
-        const start = document.createElement('button');
-        start.type = 'button';
-        start.textContent = 'Start';
-        start.style.cssText = 'padding:6px 14px;border:1px solid #007bff;border-radius:4px;background:#007bff;color:#fff;cursor:pointer;font-weight:600;';
-        start.onclick = function () {
-            onStart(matches);
-        };
+        const start = makeButton('Start', true);
+        start.onclick = function () { onStart(matches); };
         actions.appendChild(cancel);
         actions.appendChild(start);
         overlay.appendChild(actions);
@@ -323,26 +585,41 @@
 
         const actions = document.createElement('div');
         actions.style.cssText = 'padding:10px 14px;border-top:1px solid #eee;display:flex;gap:8px;justify-content:flex-end;';
-        const stop = document.createElement('button');
-        stop.type = 'button';
-        stop.textContent = 'Stop';
-        stop.style.cssText = 'padding:6px 14px;border:1px solid #e74c3c;border-radius:4px;background:#fff;color:#e74c3c;cursor:pointer;font-weight:600;';
+        const stop = makeButton('Stop', false);
+        stop.style.borderColor = '#e74c3c';
+        stop.style.color = '#e74c3c';
+        stop.style.background = '#fff';
+        stop.style.fontWeight = '600';
         stop.onclick = onStop;
         actions.appendChild(stop);
         overlay.appendChild(actions);
     }
 
-    function renderDone(state) {
+    async function renderDone(state) {
         const overlay = ensureOverlay();
         overlay.innerHTML = '';
 
         const header = document.createElement('div');
         header.style.cssText = 'padding:12px 14px;border-bottom:1px solid #eee;font-weight:600;';
-        header.textContent = state.aborted ? 'Batch abgebrochen' : 'Batch abgeschlossen';
+        if (state.autoStopped) {
+            header.textContent = '\u26A0 Batch automatisch gestoppt';
+            header.style.color = '#a06200';
+        } else if (state.aborted) {
+            header.textContent = 'Batch abgebrochen';
+        } else {
+            header.textContent = 'Batch abgeschlossen';
+        }
         overlay.appendChild(header);
 
         const body = document.createElement('div');
         body.style.cssText = 'padding:10px 14px;line-height:1.5;';
+
+        if (state.autoStopped) {
+            const note = document.createElement('div');
+            note.style.cssText = 'background:#fff7e6;border:1px solid #ffd591;padding:8px;border-radius:4px;margin-bottom:8px;color:#a06200;font-size:12px;';
+            note.textContent = 'Möglicher Datenverlust erkannt. Prüfe die Recovery-Snapshots unten.';
+            body.appendChild(note);
+        }
 
         const okLine = document.createElement('div');
         okLine.appendChild(document.createTextNode('OK: '));
@@ -370,12 +647,14 @@
         }
         overlay.appendChild(body);
 
+        try {
+            const meta = await listSnapshotMeta();
+            await appendRecoverySection(overlay, meta);
+        } catch (e) { warn('Recovery-Listing fehlgeschlagen', e); }
+
         const actions = document.createElement('div');
         actions.style.cssText = 'padding:10px 14px;border-top:1px solid #eee;display:flex;gap:8px;justify-content:flex-end;';
-        const close = document.createElement('button');
-        close.type = 'button';
-        close.textContent = 'Schließen';
-        close.style.cssText = 'padding:6px 14px;border:1px solid #ccc;border-radius:4px;background:#f5f5f5;cursor:pointer;';
+        const close = makeButton('Schließen', false);
         close.onclick = closeOverlay;
         actions.appendChild(close);
         overlay.appendChild(actions);
@@ -384,10 +663,10 @@
     // === ORCHESTRATOR ===
     let stopRequested = false;
 
-    function startBatchFlow() {
+    async function startBatchFlow() {
         const result = collectCandidates();
         log('Kandidaten:', { matches: result.matches.length, skipped: result.skipped.length });
-        renderConfirm(result.matches, result.skipped, function (matches) {
+        await renderConfirm(result.matches, result.skipped, function (matches) {
             stopRequested = false;
             runBatch(matches);
         });
@@ -410,20 +689,22 @@
                 '_blank'
             );
             if (!tabRef) {
-                resolve({ ok: false, error: 'Popup blockiert' });
+                resolve({ ok: false, error: 'Popup blockiert', code: 'popup_blocked', keepTab: false });
                 return;
             }
 
-            const cleanup = function () {
+            const cleanup = function (closeTab) {
                 window.removeEventListener('storage', onStorage);
                 clearTimeout(timeoutId);
                 clearInterval(pollId);
-                try { tabRef.close(); } catch (e) {}
+                if (closeTab) {
+                    try { tabRef.close(); } catch (e) {}
+                }
                 try { localStorage.removeItem(lsKey); } catch (e) {}
             };
 
             const finish = function (payload) {
-                cleanup();
+                cleanup(payload.keepTab !== true);
                 resolve(payload);
             };
 
@@ -434,7 +715,15 @@
                     return true;
                 }
                 if (raw.indexOf('error:') === 0) {
-                    finish({ ok: false, error: raw.slice(6) || 'Worker meldet Fehler' });
+                    const tail = raw.slice(6);
+                    // tail kann 'save_failed:delete_ok' / 'save_failed:delete_failed' / 'exception:<msg>' / generischer Text sein
+                    let code = tail.split(':')[0] || 'unknown';
+                    let dataLoss = false;
+                    if (code === 'save_failed') {
+                        const sub = tail.split(':')[1] || '';
+                        dataLoss = (sub === 'delete_ok');
+                    }
+                    finish({ ok: false, error: tail, code: code, dataLoss: dataLoss, keepTab: dataLoss });
                     return true;
                 }
                 return false;
@@ -454,7 +743,7 @@
             }, 1000);
 
             const timeoutId = setTimeout(function () {
-                finish({ ok: false, error: 'Timeout: kein Result vom Worker-Tab' });
+                finish({ ok: false, error: 'Timeout: kein Result vom Worker-Tab', code: 'timeout', dataLoss: false, keepTab: false });
             }, RESULT_WAIT_TIMEOUT_MS);
         });
     }
@@ -487,7 +776,8 @@
             failed: [],
             currentLabel: '',
             nextEtaText: '',
-            aborted: false
+            aborted: false,
+            autoStopped: false
         };
 
         const onStop = function () {
@@ -509,9 +799,19 @@
             if (res.ok) {
                 state.processed.push({ adId: item.adId });
                 log('OK adId ' + item.adId);
+                // Snapshot kann gelöscht werden -- kein Datenverlust
+                try { await deleteSnapshot(item.adId); } catch (e) { warn('Snapshot-Loeschung fehlgeschlagen', e); }
             } else {
                 state.failed.push({ adId: item.adId, error: res.error });
                 warn('Fehler adId ' + item.adId, res.error);
+                if (res.dataLoss) {
+                    // P3: Auto-Stop bei Datenverlust
+                    state.autoStopped = true;
+                    log('Datenverlust erkannt -- Batch wird gestoppt. Snapshot bleibt erhalten.');
+                    break;
+                }
+                // Kein Datenverlust: Snapshot kann weg
+                try { await deleteSnapshot(item.adId); } catch (e) { warn('Snapshot-Loeschung fehlgeschlagen', e); }
             }
             renderProgress(state, onStop);
 
@@ -525,7 +825,7 @@
             }
         }
 
-        log('Batch fertig', { ok: state.processed.length, fail: state.failed.length, aborted: state.aborted });
+        log('Batch fertig', { ok: state.processed.length, fail: state.failed.length, aborted: state.aborted, autoStopped: state.autoStopped });
         renderDone(state);
     }
 

--- a/helper.user.js
+++ b/helper.user.js
@@ -697,6 +697,7 @@
                 window.removeEventListener('storage', onStorage);
                 clearTimeout(timeoutId);
                 clearInterval(pollId);
+                if (saveVerifyTimer) clearTimeout(saveVerifyTimer);
                 if (closeTab) {
                     try { tabRef.close(); } catch (e) {}
                 }
@@ -708,15 +709,67 @@
                 resolve(payload);
             };
 
+            // Save-Verifikation: Worker schreibt 'save_clicked:<deleteState>'
+            // bevor er den Click absendet. Wir uebernehmen ab dort die
+            // URL-Beobachtung des Worker-Tabs, weil dessen JS-Context bei
+            // Navigation stirbt.
+            let saveVerifyTimer = null;
+            const SAVE_VERIFY_TIMEOUT_MS = 60 * 1000;
+            const SAVE_VERIFY_POLL_MS = 1000;
+
+            const startSaveVerify = function (deleteState) {
+                const verifyStart = Date.now();
+                const verifyTick = function () {
+                    if (tabRef.closed) {
+                        finish({
+                            ok: false,
+                            error: 'save_aborted',
+                            code: 'save_aborted',
+                            dataLoss: deleteState === 'delete_ok',
+                            keepTab: false
+                        });
+                        return;
+                    }
+                    let href = '';
+                    try { href = tabRef.location.href || ''; } catch (e) {
+                        // Cross-Origin-Block (sollte same-origin nicht passieren) -> retry
+                    }
+                    if (href.indexOf('/p-anzeige-aufgeben-bestaetigung.html') >= 0) {
+                        finish({ ok: true });
+                        return;
+                    }
+                    if (Date.now() - verifyStart >= SAVE_VERIFY_TIMEOUT_MS) {
+                        finish({
+                            ok: false,
+                            error: 'save_failed:' + deleteState,
+                            code: 'save_failed',
+                            dataLoss: deleteState === 'delete_ok',
+                            keepTab: deleteState === 'delete_ok'
+                        });
+                        return;
+                    }
+                    saveVerifyTimer = setTimeout(verifyTick, SAVE_VERIFY_POLL_MS);
+                };
+                verifyTick();
+            };
+
             const handleValue = function (raw) {
                 if (!raw) return false;
                 if (raw === 'ok') {
                     finish({ ok: true });
                     return true;
                 }
+                if (raw.indexOf('save_clicked:') === 0) {
+                    // Save abgesendet, ab jetzt URL-Polling im Helper-Tab.
+                    // Den Result-Key abraeumen, damit wir nicht endlos triggern.
+                    try { localStorage.removeItem(lsKey); } catch (e) {}
+                    const deleteState = raw.split(':')[1] || 'delete_ok';
+                    log('Save abgesendet (' + deleteState + '), starte URL-Verifikation');
+                    startSaveVerify(deleteState);
+                    return true;
+                }
                 if (raw.indexOf('error:') === 0) {
                     const tail = raw.slice(6);
-                    // tail kann 'save_failed:delete_ok' / 'save_failed:delete_failed' / 'exception:<msg>' / generischer Text sein
                     let code = tail.split(':')[0] || 'unknown';
                     let dataLoss = false;
                     if (code === 'save_failed') {

--- a/helper.user.js
+++ b/helper.user.js
@@ -1,11 +1,11 @@
-﻿// ==UserScript==
+// ==UserScript==
 // @name          eBay Kleinanzeigen - neu einstellen helper
 // @namespace     https://github.com/OldRon1977/Kleinanzeigen-Anzeigen-duplizieren
-// @description   Hilfsskript für Smart Neu-Einstellen direkt aus "Meine Anzeigen"
+// @description   Hilfsskript fuer Smart Neu-Einstellen direkt aus "Meine Anzeigen", inkl. Batch-Modus
 // @icon          https://www.kleinanzeigen.de/favicon.ico
 // @copyright     2026
 // @license       MIT
-// @version       1.1.2
+// @version       1.3.0
 // @author        panzli (Original), OldRon1977 (Anpassungen)
 // @match         https://www.kleinanzeigen.de/m-meine-anzeigen.html*
 // @match         https://kleinanzeigen.de/m-meine-anzeigen.html*
@@ -20,12 +20,34 @@
 (function () {
     'use strict';
 
-    const MARKER = 'data-ka-smart-helper';
+    // === KONSTANTEN ===
+    // Default Anzeigenlaufzeit auf Kleinanzeigen = 60 Tage. Eine Anzeige gilt
+    // als "älter als 7 Tage", wenn das Enddatum höchstens (60 - 7) = 53 Tage
+    // in der Zukunft liegt.
+    const MIN_DAYS_TO_END = 53;
 
+    // Jitter-Delay zwischen zwei Smart-Republish-Vorgaengen: 7 +- 2 Minuten.
+    const DELAY_BASE_MS = 7 * 60 * 1000;
+    const DELAY_JITTER_MS = 2 * 60 * 1000;
+
+    // Maximaler Wartepuffer auf das Result-Signal aus dem Worker-Tab.
+    const RESULT_WAIT_TIMEOUT_MS = 90 * 1000;
+
+    // localStorage-Schlüssel
+    const LS_RESULT_PREFIX = 'ka-batch-result-';
+
+    const MARKER = 'data-ka-smart-helper';
+    const TRIGGER_BTN_ID = 'ka-batch-trigger';
+    const OVERLAY_ID = 'ka-batch-overlay';
+
+    // === LOGGING ===
+    const log = (msg, data) => console.log('[KA-Helper] ' + msg, data || '');
+    const warn = (msg, data) => console.warn('[KA-Helper] ' + msg, data || '');
+
+    // === EINZEL-BUTTON PRO ANZEIGE (bestehende Funktion) ===
     function addControlButtons() {
         const elements = document.querySelectorAll('a[href*="/p-anzeige-bearbeiten.html?adId="]');
         elements.forEach(function (element) {
-            // Robuste Duplikat-Erkennung per data-Attribut statt nextSibling
             if (element.hasAttribute(MARKER)) return;
             element.setAttribute(MARKER, 'true');
 
@@ -45,7 +67,6 @@
                 openSmartRepublish(adId, btn);
             };
 
-            // Button direkt nach dem Bearbeiten-Link einfügen
             element.after(btn);
         });
     }
@@ -59,14 +80,467 @@
         button.textContent = '\u2705 Geöffnet';
     }
 
-    // Initiale Ausführung mit Verzögerung für SPA-Rendering
-    setTimeout(addControlButtons, 1500);
+    // === GLOBALER BATCH-TRIGGER-BUTTON ===
+    function addBatchTriggerButton() {
+        if (document.getElementById(TRIGGER_BTN_ID)) return;
 
-    // MutationObserver mit Debounce gegen Performance-Probleme
+        const list = document.querySelector('#my-manageitems-adlist');
+        if (!list) return;
+
+        const btn = document.createElement('button');
+        btn.id = TRIGGER_BTN_ID;
+        btn.type = 'button';
+        btn.textContent = '\u23F0 Alle alten neu einstellen';
+        btn.title = 'Stellt alle Anzeigen älter als 7 Tage nacheinander mit Zeitabstand neu ein';
+        btn.style.cssText = [
+            'margin: 0 0 12px 0',
+            'padding: 8px 16px',
+            'cursor: pointer',
+            'border: 1px solid #007bff',
+            'border-radius: 6px',
+            'background: #007bff',
+            'color: #fff',
+            'font-size: 13px',
+            'font-weight: 600'
+        ].join(';');
+
+        btn.onclick = function () {
+            startBatchFlow();
+        };
+
+        list.parentElement.insertBefore(btn, list);
+    }
+
+    // === KARTEN AUSWÄHLEN ===
+    function parseEndDate(dateStr) {
+        const m = (dateStr || '').match(/^(\d{1,2})\.(\d{1,2})\.(\d{4})$/);
+        if (!m) return null;
+        const d = new Date(parseInt(m[3], 10), parseInt(m[2], 10) - 1, parseInt(m[1], 10));
+        return isNaN(d.getTime()) ? null : d;
+    }
+
+    function daysUntil(date) {
+        const today = new Date();
+        today.setHours(0, 0, 0, 0);
+        const dayMs = 24 * 60 * 60 * 1000;
+        return Math.round((date.getTime() - today.getTime()) / dayMs);
+    }
+
+    function collectCandidates() {
+        const cards = document.querySelectorAll('li[data-testid="ad-card"][data-adid]');
+        const matches = [];
+        const skipped = [];
+
+        cards.forEach(function (card) {
+            const adId = card.getAttribute('data-adid');
+            const titleEl = card.querySelector('h3 a');
+            const title = titleEl ? titleEl.textContent.trim() : '(ohne Titel)';
+            const endEl = card.querySelector('.managead-listitem-enddate');
+            const endText = endEl ? endEl.textContent.trim() : '';
+            const endDate = parseEndDate(endText);
+
+            if (!adId || !endDate) {
+                skipped.push({ adId: adId, title: title, reason: 'kein Datum' });
+                return;
+            }
+
+            const days = daysUntil(endDate);
+            if (days <= MIN_DAYS_TO_END) {
+                matches.push({ adId: adId, title: title, endText: endText, daysLeft: days });
+            }
+        });
+
+        return { matches: matches, skipped: skipped };
+    }
+
+    // === OVERLAY ===
+    function ensureOverlay() {
+        let overlay = document.getElementById(OVERLAY_ID);
+        if (overlay) return overlay;
+
+        overlay = document.createElement('div');
+        overlay.id = OVERLAY_ID;
+        overlay.style.cssText = [
+            'position: fixed',
+            'top: 20px',
+            'right: 20px',
+            'width: 360px',
+            'max-height: 70vh',
+            'overflow-y: auto',
+            'background: #fff',
+            'border: 1px solid #d0d0d0',
+            'border-radius: 8px',
+            'box-shadow: 0 6px 24px rgba(0,0,0,0.18)',
+            'z-index: 100000',
+            'font-family: system-ui, sans-serif',
+            'font-size: 13px',
+            'color: #222'
+        ].join(';');
+        document.body.appendChild(overlay);
+        return overlay;
+    }
+
+    function closeOverlay() {
+        const overlay = document.getElementById(OVERLAY_ID);
+        if (overlay) overlay.remove();
+    }
+
+    function escapeHtml(s) {
+        return String(s)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+    }
+
+    function renderConfirm(matches, skipped, onStart) {
+        const overlay = ensureOverlay();
+        const totalMs = matches.length * (DELAY_BASE_MS);
+        const minutes = Math.round(totalMs / 60000);
+
+        overlay.innerHTML = '';
+
+        const header = document.createElement('div');
+        header.style.cssText = 'padding:12px 14px;border-bottom:1px solid #eee;font-weight:600;display:flex;justify-content:space-between;align-items:center;';
+        const title = document.createElement('span');
+        title.textContent = 'Batch Smart Neu-Einstellen';
+        header.appendChild(title);
+        const closeBtn = document.createElement('button');
+        closeBtn.type = 'button';
+        closeBtn.textContent = '\u2715';
+        closeBtn.style.cssText = 'background:none;border:none;cursor:pointer;font-size:16px;color:#888;';
+        closeBtn.onclick = closeOverlay;
+        header.appendChild(closeBtn);
+        overlay.appendChild(header);
+
+        const summary = document.createElement('div');
+        summary.style.cssText = 'padding:10px 14px;border-bottom:1px solid #eee;';
+        if (matches.length === 0) {
+            summary.textContent = 'Keine Anzeigen älter als 7 Tage gefunden.';
+            overlay.appendChild(summary);
+            return;
+        }
+        const line1 = document.createElement('div');
+        const strong = document.createElement('strong');
+        strong.textContent = matches.length;
+        line1.appendChild(strong);
+        line1.appendChild(document.createTextNode(' Anzeige(n) werden bearbeitet.'));
+        summary.appendChild(line1);
+        const line2 = document.createElement('div');
+        line2.style.cssText = 'color:#666;margin-top:4px;';
+        line2.textContent = 'Geschätzte Laufzeit: ca. ' + minutes + ' Minuten (7 ± 2 min Pause pro Anzeige).';
+        summary.appendChild(line2);
+        overlay.appendChild(summary);
+
+        const list = document.createElement('ol');
+        list.style.cssText = 'margin:0;padding:8px 14px 8px 32px;max-height:240px;overflow-y:auto;';
+        matches.forEach(function (m) {
+            const li = document.createElement('li');
+            li.style.cssText = 'margin:4px 0;line-height:1.3;';
+            const t = document.createElement('div');
+            t.style.cssText = 'font-weight:500;';
+            t.textContent = m.title;
+            const meta = document.createElement('div');
+            meta.style.cssText = 'color:#666;font-size:12px;';
+            meta.textContent = 'ID ' + m.adId + ' \u00B7 endet ' + m.endText + ' (' + m.daysLeft + ' Tage)';
+            li.appendChild(t);
+            li.appendChild(meta);
+            list.appendChild(li);
+        });
+        overlay.appendChild(list);
+
+        if (skipped.length > 0) {
+            const sk = document.createElement('div');
+            sk.style.cssText = 'padding:8px 14px;color:#888;font-size:12px;border-top:1px solid #eee;';
+            sk.textContent = skipped.length + ' Karte(n) ohne Datum übersprungen.';
+            overlay.appendChild(sk);
+        }
+
+        const actions = document.createElement('div');
+        actions.style.cssText = 'padding:10px 14px;border-top:1px solid #eee;display:flex;gap:8px;justify-content:flex-end;';
+        const cancel = document.createElement('button');
+        cancel.type = 'button';
+        cancel.textContent = 'Abbrechen';
+        cancel.style.cssText = 'padding:6px 14px;border:1px solid #ccc;border-radius:4px;background:#f5f5f5;cursor:pointer;';
+        cancel.onclick = closeOverlay;
+        const start = document.createElement('button');
+        start.type = 'button';
+        start.textContent = 'Start';
+        start.style.cssText = 'padding:6px 14px;border:1px solid #007bff;border-radius:4px;background:#007bff;color:#fff;cursor:pointer;font-weight:600;';
+        start.onclick = function () {
+            onStart(matches);
+        };
+        actions.appendChild(cancel);
+        actions.appendChild(start);
+        overlay.appendChild(actions);
+    }
+
+    function renderProgress(state, onStop) {
+        const overlay = ensureOverlay();
+        overlay.innerHTML = '';
+
+        const header = document.createElement('div');
+        header.style.cssText = 'padding:12px 14px;border-bottom:1px solid #eee;font-weight:600;';
+        header.textContent = 'Batch läuft \u2026';
+        overlay.appendChild(header);
+
+        const status = document.createElement('div');
+        status.style.cssText = 'padding:10px 14px;line-height:1.4;';
+        const idx = state.processed.length + state.failed.length;
+        const total = state.queue.length + idx;
+
+        const main = document.createElement('div');
+        const strong = document.createElement('strong');
+        strong.textContent = idx + ' / ' + total;
+        main.appendChild(strong);
+        main.appendChild(document.createTextNode(' Anzeigen verarbeitet.'));
+        status.appendChild(main);
+
+        const cur = document.createElement('div');
+        cur.style.cssText = 'color:#666;margin-top:4px;';
+        cur.textContent = 'Aktuell: ' + (state.currentLabel || '\u2013');
+        status.appendChild(cur);
+
+        if (state.nextEtaText) {
+            const eta = document.createElement('div');
+            eta.style.cssText = 'color:#666;margin-top:4px;';
+            eta.textContent = 'Nächste in: ' + state.nextEtaText;
+            status.appendChild(eta);
+        }
+
+        const ok = document.createElement('div');
+        ok.style.cssText = 'color:#27ae60;margin-top:6px;';
+        ok.textContent = 'OK: ' + state.processed.length;
+        status.appendChild(ok);
+
+        const fail = document.createElement('div');
+        fail.style.cssText = 'color:#e74c3c;';
+        fail.textContent = 'Fehler: ' + state.failed.length;
+        status.appendChild(fail);
+
+        overlay.appendChild(status);
+
+        const actions = document.createElement('div');
+        actions.style.cssText = 'padding:10px 14px;border-top:1px solid #eee;display:flex;gap:8px;justify-content:flex-end;';
+        const stop = document.createElement('button');
+        stop.type = 'button';
+        stop.textContent = 'Stop';
+        stop.style.cssText = 'padding:6px 14px;border:1px solid #e74c3c;border-radius:4px;background:#fff;color:#e74c3c;cursor:pointer;font-weight:600;';
+        stop.onclick = onStop;
+        actions.appendChild(stop);
+        overlay.appendChild(actions);
+    }
+
+    function renderDone(state) {
+        const overlay = ensureOverlay();
+        overlay.innerHTML = '';
+
+        const header = document.createElement('div');
+        header.style.cssText = 'padding:12px 14px;border-bottom:1px solid #eee;font-weight:600;';
+        header.textContent = state.aborted ? 'Batch abgebrochen' : 'Batch abgeschlossen';
+        overlay.appendChild(header);
+
+        const body = document.createElement('div');
+        body.style.cssText = 'padding:10px 14px;line-height:1.5;';
+
+        const okLine = document.createElement('div');
+        okLine.appendChild(document.createTextNode('OK: '));
+        const okStrong = document.createElement('strong');
+        okStrong.textContent = state.processed.length;
+        okLine.appendChild(okStrong);
+        body.appendChild(okLine);
+
+        const failLine = document.createElement('div');
+        failLine.appendChild(document.createTextNode('Fehler: '));
+        const failStrong = document.createElement('strong');
+        failStrong.textContent = state.failed.length;
+        failLine.appendChild(failStrong);
+        body.appendChild(failLine);
+
+        if (state.failed.length > 0) {
+            const ul = document.createElement('ul');
+            ul.style.cssText = 'margin:6px 0 0 18px;color:#e74c3c;font-size:12px;';
+            state.failed.forEach(function (f) {
+                const li = document.createElement('li');
+                li.textContent = f.adId + ': ' + (f.error || 'unbekannter Fehler');
+                ul.appendChild(li);
+            });
+            body.appendChild(ul);
+        }
+        overlay.appendChild(body);
+
+        const actions = document.createElement('div');
+        actions.style.cssText = 'padding:10px 14px;border-top:1px solid #eee;display:flex;gap:8px;justify-content:flex-end;';
+        const close = document.createElement('button');
+        close.type = 'button';
+        close.textContent = 'Schließen';
+        close.style.cssText = 'padding:6px 14px;border:1px solid #ccc;border-radius:4px;background:#f5f5f5;cursor:pointer;';
+        close.onclick = closeOverlay;
+        actions.appendChild(close);
+        overlay.appendChild(actions);
+    }
+
+    // === ORCHESTRATOR ===
+    let stopRequested = false;
+
+    function startBatchFlow() {
+        const result = collectCandidates();
+        log('Kandidaten:', { matches: result.matches.length, skipped: result.skipped.length });
+        renderConfirm(result.matches, result.skipped, function (matches) {
+            stopRequested = false;
+            runBatch(matches);
+        });
+    }
+
+    function jitterDelay() {
+        const offset = (Math.random() * 2 - 1) * DELAY_JITTER_MS;
+        return Math.max(60 * 1000, Math.round(DELAY_BASE_MS + offset));
+    }
+
+    function processOne(item) {
+        return new Promise(function (resolve) {
+            const adId = item.adId;
+            const lsKey = LS_RESULT_PREFIX + adId;
+            try { localStorage.removeItem(lsKey); } catch (e) {}
+
+            log('Öffne Tab für adId ' + adId);
+            const tabRef = window.open(
+                'https://www.kleinanzeigen.de/p-anzeige-bearbeiten.html?adId=' + adId + '#smartRepublish',
+                '_blank'
+            );
+            if (!tabRef) {
+                resolve({ ok: false, error: 'Popup blockiert' });
+                return;
+            }
+
+            const cleanup = function () {
+                window.removeEventListener('storage', onStorage);
+                clearTimeout(timeoutId);
+                clearInterval(pollId);
+                try { tabRef.close(); } catch (e) {}
+                try { localStorage.removeItem(lsKey); } catch (e) {}
+            };
+
+            const finish = function (payload) {
+                cleanup();
+                resolve(payload);
+            };
+
+            const handleValue = function (raw) {
+                if (!raw) return false;
+                if (raw === 'ok') {
+                    finish({ ok: true });
+                    return true;
+                }
+                if (raw.indexOf('error:') === 0) {
+                    finish({ ok: false, error: raw.slice(6) || 'Worker meldet Fehler' });
+                    return true;
+                }
+                return false;
+            };
+
+            const onStorage = function (e) {
+                if (e.key !== lsKey) return;
+                handleValue(e.newValue);
+            };
+            window.addEventListener('storage', onStorage);
+
+            const pollId = setInterval(function () {
+                try {
+                    const v = localStorage.getItem(lsKey);
+                    if (v) handleValue(v);
+                } catch (err) {}
+            }, 1000);
+
+            const timeoutId = setTimeout(function () {
+                finish({ ok: false, error: 'Timeout: kein Result vom Worker-Tab' });
+            }, RESULT_WAIT_TIMEOUT_MS);
+        });
+    }
+
+    function waitMs(ms, onTick) {
+        return new Promise(function (resolve) {
+            const start = Date.now();
+            const tick = setInterval(function () {
+                const remaining = Math.max(0, ms - (Date.now() - start));
+                if (onTick) onTick(remaining);
+                if (remaining <= 0) {
+                    clearInterval(tick);
+                    resolve();
+                }
+            }, 1000);
+        });
+    }
+
+    function formatRemaining(ms) {
+        const sec = Math.round(ms / 1000);
+        const m = Math.floor(sec / 60);
+        const s = sec % 60;
+        return m + ':' + (s < 10 ? '0' : '') + s;
+    }
+
+    async function runBatch(matches) {
+        const state = {
+            queue: matches.slice(),
+            processed: [],
+            failed: [],
+            currentLabel: '',
+            nextEtaText: '',
+            aborted: false
+        };
+
+        const onStop = function () {
+            stopRequested = true;
+            state.aborted = true;
+            log('Stop angefordert');
+        };
+
+        renderProgress(state, onStop);
+
+        while (state.queue.length > 0) {
+            if (stopRequested) break;
+            const item = state.queue.shift();
+            state.currentLabel = item.title + ' (ID ' + item.adId + ')';
+            state.nextEtaText = '';
+            renderProgress(state, onStop);
+
+            const res = await processOne(item);
+            if (res.ok) {
+                state.processed.push({ adId: item.adId });
+                log('OK adId ' + item.adId);
+            } else {
+                state.failed.push({ adId: item.adId, error: res.error });
+                warn('Fehler adId ' + item.adId, res.error);
+            }
+            renderProgress(state, onStop);
+
+            if (state.queue.length > 0 && !stopRequested) {
+                const wait = jitterDelay();
+                log('Warte ' + Math.round(wait / 1000) + 's vor nächster Anzeige');
+                await waitMs(wait, function (remaining) {
+                    state.nextEtaText = formatRemaining(remaining);
+                    renderProgress(state, onStop);
+                });
+            }
+        }
+
+        log('Batch fertig', { ok: state.processed.length, fail: state.failed.length, aborted: state.aborted });
+        renderDone(state);
+    }
+
+    // === INIT ===
+    function tick() {
+        addControlButtons();
+        addBatchTriggerButton();
+    }
+
+    setTimeout(tick, 1500);
+
     let debounceTimer;
     const observer = new MutationObserver(function () {
         clearTimeout(debounceTimer);
-        debounceTimer = setTimeout(addControlButtons, 300);
+        debounceTimer = setTimeout(tick, 300);
     });
     observer.observe(document.body, { childList: true, subtree: true });
 })();

--- a/helper.user.js
+++ b/helper.user.js
@@ -721,13 +721,33 @@
                 const verifyStart = Date.now();
                 const verifyTick = function () {
                     if (tabRef.closed) {
-                        finish({
-                            ok: false,
-                            error: 'save_aborted',
-                            code: 'save_aborted',
-                            dataLoss: deleteState === 'delete_ok',
-                            keepTab: false
-                        });
+                        // Tab ist weg. Wenn der Worker auf der Bestaetigungs-Seite
+                        // selbst 'ok' ins localStorage geschrieben hat, wird der
+                        // storage-Event-Listener das gleich verarbeiten. Hier nur
+                        // dann 'save_aborted' melden, wenn nichts mehr eintrudelt.
+                        let okFlag = null;
+                        try { okFlag = localStorage.getItem(lsKey); } catch (e) {}
+                        if (okFlag === 'ok') {
+                            finish({ ok: true });
+                            return;
+                        }
+                        // Kurz warten, dann final entscheiden -- gibt dem
+                        // storage-Event etwas Luft, den Listener zu erreichen.
+                        setTimeout(function () {
+                            let late = null;
+                            try { late = localStorage.getItem(lsKey); } catch (e) {}
+                            if (late === 'ok') {
+                                finish({ ok: true });
+                            } else {
+                                finish({
+                                    ok: false,
+                                    error: 'save_aborted',
+                                    code: 'save_aborted',
+                                    dataLoss: deleteState === 'delete_ok',
+                                    keepTab: deleteState === 'delete_ok'
+                                });
+                            }
+                        }, 1500);
                         return;
                     }
                     let href = '';
@@ -760,9 +780,12 @@
                     return true;
                 }
                 if (raw.indexOf('save_clicked:') === 0) {
-                    // Save abgesendet, ab jetzt URL-Polling im Helper-Tab.
-                    // Den Result-Key abraeumen, damit wir nicht endlos triggern.
-                    try { localStorage.removeItem(lsKey); } catch (e) {}
+                    // Save abgesendet. URL-Polling im Helper-Tab uebernimmt ab hier.
+                    // Wir merken uns, dass der Click-Marker schon verarbeitet wurde,
+                    // damit pollId nicht endlos triggert. Aber: Result-Key NICHT loeschen,
+                    // weil der Worker auf der Bestaetigungs-Seite gleich 'ok' reinschreibt.
+                    if (saveVerifyTimer === 'pending' || saveVerifyTimer) return true;
+                    saveVerifyTimer = 'pending';
                     const deleteState = raw.split(':')[1] || 'delete_ok';
                     log('Save abgesendet (' + deleteState + '), starte URL-Verifikation');
                     startSaveVerify(deleteState);

--- a/kleinanzeigen-duplizieren.user.js
+++ b/kleinanzeigen-duplizieren.user.js
@@ -5,7 +5,7 @@
 // @icon          https://www.kleinanzeigen.de/favicon.ico
 // @copyright     2026
 // @license       MIT
-// @version       3.4.0
+// @version       3.5.0
 // @author        OldRon1977 (Improvements), J05HI (Original)
 // @credits       Basierend auf dem Original-Script von J05HI (https://gist.github.com/J05HI/9f3fc7a496e8baeff5a56e0c1a710bb5)
 // @match         https://www.kleinanzeigen.de/p-anzeige-bearbeiten.html*
@@ -396,6 +396,8 @@
 
             // Popup-Dismisser starten bevor wir klicken
             startPopupDismisser();
+            // Batch-Worker: Erfolg an Helper-Tab signalisieren (vor Navigation)
+            try { localStorage.setItem('ka-batch-result-' + originalId, 'ok'); } catch (e) { logger.warn('localStorage write fehlgeschlagen', e); }
             saveBtn.click();
 
         } catch (error) {
@@ -403,6 +405,11 @@
             showNotification('Fehler: ' + error.message, 'error');
             showLoadingSpinner(false);
             document.querySelectorAll('.ka-duplicate-btn, .ka-smart-btn').forEach(btn => btn.disabled = false);
+            // Batch-Worker: Fehler an Helper-Tab signalisieren
+            try {
+                const m = window.location.search.match(/adId=(\d+)/);
+                if (m) localStorage.setItem('ka-batch-result-' + m[1], 'error:' + (error.message || 'unbekannt'));
+            } catch (e) {}
         }
     }
 
@@ -482,7 +489,7 @@
 
     // === INITIALISIERUNG ===
     function init() {
-        logger.log('UserScript initialisiert (v3.4.0)');
+        logger.log('UserScript initialisiert (v3.5.0)');
 
         // Banner-Blocker sofort injizieren
         injectBannerBlockerStyles();

--- a/kleinanzeigen-duplizieren.user.js
+++ b/kleinanzeigen-duplizieren.user.js
@@ -525,14 +525,9 @@
 
             startPopupDismisser();
             if (batchMode) {
-                // Click-Marker: signalisiert dem Helper, dass die Save-Action
-                // abgesendet wurde. Die Erfolgs-Verifikation laeuft im Helper-Tab,
-                // weil dieser Tab gleich wegnavigiert und sein JS-Context stirbt.
-                batchSetResult(originalId, 'save_clicked:' + (deleteFailed ? 'delete_failed' : 'delete_ok'));
-                // Self-Close-Marker fuer die Bestaetigungs-Seite:
-                // dort liest das Skript ihn aus, schreibt 'ok' ins localStorage
-                // und schliesst den Tab selbst (window.close darf nur der eigene Tab).
-                try { sessionStorage.setItem('ka-batch-close-marker', originalId); } catch (e) {}
+                // Marker fuer die Bestaetigungs-Seite: dort wird 'ok' an den Helper
+                // gemeldet. Der Helper schliesst den Tab via GM_openInTab.close().
+                try { sessionStorage.setItem('ka-batch-original-adid', originalId); } catch (e) {}
             }
             saveBtn.click();
 
@@ -625,17 +620,16 @@
     function init() {
         logger.log('UserScript initialisiert (v3.5.0)');
 
-        // Wenn wir auf der Bestaetigungs-Seite gelandet sind und ein Batch-Marker
-        // im sessionStorage liegt: Erfolg an Helper signalisieren und Tab schliessen.
+        // Wenn wir auf der Bestaetigungs-Seite gelandet sind und der Batch-Marker
+        // im sessionStorage liegt: Erfolg an den Helper signalisieren. Den Tab
+        // schliesst der Helper-Tab per GM_openInTab.close().
         if (window.location.pathname.indexOf('/p-anzeige-aufgeben-bestaetigung.html') === 0) {
             try {
-                const origAdId = sessionStorage.getItem('ka-batch-close-marker');
+                const origAdId = sessionStorage.getItem('ka-batch-original-adid');
                 if (origAdId) {
-                    sessionStorage.removeItem('ka-batch-close-marker');
+                    sessionStorage.removeItem('ka-batch-original-adid');
                     logger.log('Bestaetigungs-Seite erreicht, signalisiere ok an Helper', { origAdId: origAdId });
                     try { localStorage.setItem('ka-batch-result-' + origAdId, 'ok'); } catch (e) {}
-                    // Kurze Verzoegerung, damit Helper das storage-Event verarbeiten kann
-                    setTimeout(function () { try { window.close(); } catch (e) {} }, 500);
                 }
             } catch (e) {
                 logger.warn('Bestaetigungs-Seite Hook fehlgeschlagen', e);

--- a/kleinanzeigen-duplizieren.user.js
+++ b/kleinanzeigen-duplizieren.user.js
@@ -469,6 +469,9 @@
         const urlMatch = window.location.search.match(/adId=(\d+)/);
         const originalId = urlMatch ? urlMatch[1] : null;
         const batchMode = isBatchMode();
+        // Lifecycle-Marker fuer differenzierte Fehlerklassifikation:
+        // wenn nach erfolgreichem Delete etwas schief geht, ist das Datenverlust.
+        let phase = 'init';
 
         try {
             logger.log('Starte Smart-Republish-Prozess', { batchMode: batchMode, originalId: originalId });
@@ -476,12 +479,19 @@
 
             if (!originalId) throw new Error('Keine Anzeigen-ID in URL gefunden');
 
+            // Defensive: alten Result-Key abraeumen, falls ein vorheriger Run
+            // crashte und einen Stale-Wert hinterlassen hat.
+            if (batchMode) {
+                try { localStorage.removeItem('ka-batch-result-' + originalId); } catch (e) {}
+            }
+
             // Snapshot VOR Loeschung speichern (atomar, erst dann weiter)
             if (batchMode) {
                 try {
                     showNotification('Snapshot wird erstellt...');
                     const snap = await buildSnapshot(originalId);
                     await batchPutSnapshot(snap);
+                    phase = 'snapshot_done';
                     logger.log('Snapshot gespeichert', { adId: originalId, images: snap.images.length });
                 } catch (e) {
                     logger.error('Snapshot fehlgeschlagen, Abbruch vor Loeschung', e);
@@ -500,9 +510,11 @@
             try {
                 await deleteAd(originalId);
                 await delay(CONFIG.DELETE_WAIT_BEFORE_CREATE_MS);
+                phase = 'delete_ok';
                 logger.log('Original-Anzeige erfolgreich gelöscht');
             } catch (error) {
                 deleteFailed = true;
+                phase = 'delete_failed';
                 logger.warn('Loeschung fehlgeschlagen', error);
                 showNotification('Original konnte nicht gelöscht werden - erstelle trotzdem neue.', 'error');
             }
@@ -529,7 +541,23 @@
                 // gemeldet. Der Helper schliesst den Tab via GM_openInTab.close().
                 try { sessionStorage.setItem('ka-batch-original-adid', originalId); } catch (e) {}
             }
+            phase = 'save_clicked';
             saveBtn.click();
+
+            // B) Self-Watchdog: wenn der Tab nach 45s noch auf der Bearbeiten-Seite
+            // ist, hat das Save serverseitig nicht durchgegriffen. Ohne diesen
+            // Hinweis wuerde der Helper nur ein generisches Timeout sehen.
+            if (batchMode) {
+                setTimeout(function () {
+                    try {
+                        if (window.location.pathname.indexOf('/p-anzeige-bearbeiten.html') === 0) {
+                            const sub = (deleteFailed) ? 'delete_failed' : 'delete_ok';
+                            logger.error('Watchdog: Save scheint nicht navigiert zu haben', { sub: sub });
+                            batchSetResult(originalId, 'error:save_failed:' + sub);
+                        }
+                    } catch (e) {}
+                }, 45 * 1000);
+            }
 
         } catch (error) {
             logger.error('Fehler beim Smart-Republish', error);
@@ -537,7 +565,15 @@
             showLoadingSpinner(false);
             document.querySelectorAll('.ka-duplicate-btn, .ka-smart-btn').forEach(btn => btn.disabled = false);
             if (batchMode && originalId) {
-                batchSetResult(originalId, 'error:exception:' + (error.message || 'unbekannt'));
+                // Wenn Original bereits geloescht wurde, ist das Datenverlust.
+                // Helper soll Snapshot behalten und Batch stoppen.
+                if (phase === 'delete_ok' || phase === 'save_clicked') {
+                    batchSetResult(originalId, 'error:save_failed:delete_ok');
+                } else if (phase === 'delete_failed') {
+                    batchSetResult(originalId, 'error:save_failed:delete_failed');
+                } else {
+                    batchSetResult(originalId, 'error:exception:' + (error.message || 'unbekannt'));
+                }
             }
         }
     }

--- a/kleinanzeigen-duplizieren.user.js
+++ b/kleinanzeigen-duplizieren.user.js
@@ -355,16 +355,166 @@
         }
     }
 
+    // === BATCH-WORKER: Snapshot/Recovery via IndexedDB ===
+    const BATCH_IDB_NAME = 'ka-batch';
+    const BATCH_IDB_VERSION = 1;
+    const BATCH_IDB_STORE = 'snapshots';
+
+    function batchOpenIDB() {
+        return new Promise(function (resolve, reject) {
+            const req = indexedDB.open(BATCH_IDB_NAME, BATCH_IDB_VERSION);
+            req.onupgradeneeded = function () {
+                const db = req.result;
+                if (!db.objectStoreNames.contains(BATCH_IDB_STORE)) {
+                    db.createObjectStore(BATCH_IDB_STORE, { keyPath: 'adId' });
+                }
+            };
+            req.onsuccess = function () { resolve(req.result); };
+            req.onerror = function () { reject(req.error); };
+        });
+    }
+    function batchPutSnapshot(snap) {
+        return batchOpenIDB().then(function (db) {
+            return new Promise(function (resolve, reject) {
+                const tx = db.transaction(BATCH_IDB_STORE, 'readwrite');
+                const req = tx.objectStore(BATCH_IDB_STORE).put(snap);
+                req.onsuccess = function () { resolve(); };
+                req.onerror = function () { reject(req.error); };
+            });
+        });
+    }
+
+    function batchSetResult(adId, value) {
+        try { localStorage.setItem('ka-batch-result-' + adId, value); }
+        catch (e) { logger.warn('localStorage write fehlgeschlagen', e); }
+    }
+
+    function isBatchMode() { return window.location.hash === '#smartRepublish'; }
+
+    function readFormFields() {
+        const fields = {};
+        const rawFields = {};
+        document.querySelectorAll('input, textarea, select').forEach(function (el) {
+            const name = el.getAttribute('name');
+            if (!name) return;
+            if (el.type === 'checkbox' || el.type === 'radio') {
+                if (!el.checked) return;
+            }
+            if (el.type === 'password' || el.type === 'file') return;
+            const v = el.value;
+            if (v === undefined || v === null || v === '') return;
+            rawFields[name] = String(v).slice(0, 5000);
+        });
+        const titleInput = document.querySelector('input[name="title"], input#title');
+        if (titleInput) fields.title = titleInput.value;
+        const descTa = document.querySelector('textarea[name="description"], textarea#description');
+        if (descTa) fields.description = descTa.value;
+        const priceInput = document.querySelector('input[name="price"], input#price');
+        if (priceInput) fields.price = priceInput.value;
+        const priceTypeSel = document.querySelector('select[name="priceType"], select#priceType');
+        if (priceTypeSel) fields.priceType = priceTypeSel.value;
+        const locInput = document.querySelector('input[name="locationStr"], input#locationStr, input[name="zipCode"]');
+        if (locInput) fields.location = locInput.value;
+        return { fields: fields, rawFields: rawFields };
+    }
+
+    function collectImageUrls() {
+        const urls = new Set();
+        document.querySelectorAll('img').forEach(function (img) {
+            const src = img.src || img.getAttribute('data-src') || '';
+            if (src && src.indexOf('img.kleinanzeigen.de') >= 0 && src.indexOf('/prod-ads/images/') >= 0) {
+                // Auf groesste Variante normalisieren (rule=$_57.JPG = full size)
+                const url = src.replace(/[?&]rule=\$_\d+\.[A-Z]+/i, '?rule=$_57.JPG');
+                urls.add(url);
+            }
+        });
+        return Array.from(urls);
+    }
+
+    async function fetchAsBlob(url) {
+        const res = await fetch(url, { credentials: 'include' });
+        if (!res.ok) throw new Error('HTTP ' + res.status);
+        return await res.blob();
+    }
+
+    async function buildSnapshot(adId) {
+        const ff = readFormFields();
+        const urls = collectImageUrls();
+        const images = [];
+        for (const u of urls) {
+            try {
+                const blob = await fetchAsBlob(u);
+                images.push({ url: u, blob: blob, mime: blob.type || 'image/jpeg' });
+            } catch (e) {
+                logger.warn('Bild-Fetch fehlgeschlagen, speichere nur URL', { url: u, error: String(e) });
+                images.push({ url: u, blob: null, mime: null });
+            }
+        }
+        return {
+            adId: String(adId),
+            capturedAt: Date.now(),
+            title: ff.fields.title || '',
+            fields: ff.fields,
+            rawFields: ff.rawFields,
+            images: images
+        };
+    }
+
+    function waitForSaveSuccess(originalId, timeoutMs) {
+        // Erfolg: Pfad verlaesst /p-anzeige-bearbeiten.html ODER
+        //          eine andere adId steht im URL/DOM
+        return new Promise(function (resolve) {
+            const start = Date.now();
+            const id = setInterval(function () {
+                const path = window.location.pathname;
+                if (path.indexOf('/p-anzeige-bearbeiten.html') < 0) {
+                    clearInterval(id);
+                    resolve({ ok: true, reason: 'navigation' });
+                    return;
+                }
+                const m = window.location.search.match(/adId=(\d+)/);
+                if (m && m[1] !== String(originalId)) {
+                    clearInterval(id);
+                    resolve({ ok: true, reason: 'new_adId', newAdId: m[1] });
+                    return;
+                }
+                if (Date.now() - start >= timeoutMs) {
+                    clearInterval(id);
+                    resolve({ ok: false });
+                }
+            }, 500);
+        });
+    }
+
     async function smartRepublish() {
+        const urlMatch = window.location.search.match(/adId=(\d+)/);
+        const originalId = urlMatch ? urlMatch[1] : null;
+        const batchMode = isBatchMode();
+
         try {
-            logger.log('Starte Smart-Republish-Prozess');
+            logger.log('Starte Smart-Republish-Prozess', { batchMode: batchMode, originalId: originalId });
             showLoadingSpinner();
 
-            const urlMatch = window.location.search.match(/adId=(\d+)/);
-            if (!urlMatch) throw new Error('Keine Anzeigen-ID in URL gefunden');
-            const originalId = urlMatch[1];
+            if (!originalId) throw new Error('Keine Anzeigen-ID in URL gefunden');
 
-            logger.log(`Versuche Original-Anzeige ${originalId} zu löschen`);
+            // Snapshot VOR Loeschung speichern (atomar, erst dann weiter)
+            if (batchMode) {
+                try {
+                    showNotification('Snapshot wird erstellt...');
+                    const snap = await buildSnapshot(originalId);
+                    await batchPutSnapshot(snap);
+                    logger.log('Snapshot gespeichert', { adId: originalId, images: snap.images.length });
+                } catch (e) {
+                    logger.error('Snapshot fehlgeschlagen, Abbruch vor Loeschung', e);
+                    showNotification('Snapshot fehlgeschlagen - Abbruch', 'error');
+                    showLoadingSpinner(false);
+                    document.querySelectorAll('.ka-duplicate-btn, .ka-smart-btn').forEach(btn => btn.disabled = false);
+                    batchSetResult(originalId, 'error:snapshot_failed:' + (e.message || 'unbekannt'));
+                    return;
+                }
+            }
+
+            logger.log('Versuche Original-Anzeige ' + originalId + ' zu loeschen');
             showNotification('Original wird gelöscht...');
 
             let deleteFailed = false;
@@ -374,7 +524,7 @@
                 logger.log('Original-Anzeige erfolgreich gelöscht');
             } catch (error) {
                 deleteFailed = true;
-                logger.warn('Löschung fehlgeschlagen', error);
+                logger.warn('Loeschung fehlgeschlagen', error);
                 showNotification('Original konnte nicht gelöscht werden - erstelle trotzdem neue.', 'error');
             }
 
@@ -394,22 +544,30 @@
             logger.log('Erstelle neue Anzeige', { deleteFailed });
             showNotification(statusMsg);
 
-            // Popup-Dismisser starten bevor wir klicken
             startPopupDismisser();
-            // Batch-Worker: Erfolg an Helper-Tab signalisieren (vor Navigation)
-            try { localStorage.setItem('ka-batch-result-' + originalId, 'ok'); } catch (e) { logger.warn('localStorage write fehlgeschlagen', e); }
             saveBtn.click();
+
+            if (batchMode) {
+                // Erfolgs-Verifikation per Navigation/AdId-Wechsel
+                const verify = await waitForSaveSuccess(originalId, 60000);
+                if (verify.ok) {
+                    logger.log('Save verifiziert', verify);
+                    batchSetResult(originalId, 'ok');
+                } else {
+                    const sub = deleteFailed ? 'delete_failed' : 'delete_ok';
+                    logger.error('Save-Verifikation fehlgeschlagen', { sub: sub });
+                    batchSetResult(originalId, 'error:save_failed:' + sub);
+                }
+            }
 
         } catch (error) {
             logger.error('Fehler beim Smart-Republish', error);
             showNotification('Fehler: ' + error.message, 'error');
             showLoadingSpinner(false);
             document.querySelectorAll('.ka-duplicate-btn, .ka-smart-btn').forEach(btn => btn.disabled = false);
-            // Batch-Worker: Fehler an Helper-Tab signalisieren
-            try {
-                const m = window.location.search.match(/adId=(\d+)/);
-                if (m) localStorage.setItem('ka-batch-result-' + m[1], 'error:' + (error.message || 'unbekannt'));
-            } catch (e) {}
+            if (batchMode && originalId) {
+                batchSetResult(originalId, 'error:exception:' + (error.message || 'unbekannt'));
+            }
         }
     }
 

--- a/kleinanzeigen-duplizieren.user.js
+++ b/kleinanzeigen-duplizieren.user.js
@@ -460,32 +460,6 @@
         };
     }
 
-    function waitForSaveSuccess(originalId, timeoutMs) {
-        // Erfolg: Pfad verlaesst /p-anzeige-bearbeiten.html ODER
-        //          eine andere adId steht im URL/DOM
-        return new Promise(function (resolve) {
-            const start = Date.now();
-            const id = setInterval(function () {
-                const path = window.location.pathname;
-                if (path.indexOf('/p-anzeige-bearbeiten.html') < 0) {
-                    clearInterval(id);
-                    resolve({ ok: true, reason: 'navigation' });
-                    return;
-                }
-                const m = window.location.search.match(/adId=(\d+)/);
-                if (m && m[1] !== String(originalId)) {
-                    clearInterval(id);
-                    resolve({ ok: true, reason: 'new_adId', newAdId: m[1] });
-                    return;
-                }
-                if (Date.now() - start >= timeoutMs) {
-                    clearInterval(id);
-                    resolve({ ok: false });
-                }
-            }, 500);
-        });
-    }
-
     async function smartRepublish() {
         const urlMatch = window.location.search.match(/adId=(\d+)/);
         const originalId = urlMatch ? urlMatch[1] : null;
@@ -545,20 +519,13 @@
             showNotification(statusMsg);
 
             startPopupDismisser();
-            saveBtn.click();
-
             if (batchMode) {
-                // Erfolgs-Verifikation per Navigation/AdId-Wechsel
-                const verify = await waitForSaveSuccess(originalId, 60000);
-                if (verify.ok) {
-                    logger.log('Save verifiziert', verify);
-                    batchSetResult(originalId, 'ok');
-                } else {
-                    const sub = deleteFailed ? 'delete_failed' : 'delete_ok';
-                    logger.error('Save-Verifikation fehlgeschlagen', { sub: sub });
-                    batchSetResult(originalId, 'error:save_failed:' + sub);
-                }
+                // Click-Marker: signalisiert dem Helper, dass die Save-Action
+                // abgesendet wurde. Die Erfolgs-Verifikation laeuft im Helper-Tab,
+                // weil dieser Tab gleich wegnavigiert und sein JS-Context stirbt.
+                batchSetResult(originalId, 'save_clicked:' + (deleteFailed ? 'delete_failed' : 'delete_ok'));
             }
+            saveBtn.click();
 
         } catch (error) {
             logger.error('Fehler beim Smart-Republish', error);

--- a/kleinanzeigen-duplizieren.user.js
+++ b/kleinanzeigen-duplizieren.user.js
@@ -13,6 +13,11 @@
 // @match         https://*.kleinanzeigen.de/p-anzeige-bearbeiten.html*
 // @match         https://www.ebay-kleinanzeigen.de/p-anzeige-bearbeiten.html*
 // @match         https://ebay-kleinanzeigen.de/p-anzeige-bearbeiten.html*
+// @match         https://www.kleinanzeigen.de/p-anzeige-aufgeben-bestaetigung.html*
+// @match         https://kleinanzeigen.de/p-anzeige-aufgeben-bestaetigung.html*
+// @match         https://*.kleinanzeigen.de/p-anzeige-aufgeben-bestaetigung.html*
+// @match         https://www.ebay-kleinanzeigen.de/p-anzeige-aufgeben-bestaetigung.html*
+// @match         https://ebay-kleinanzeigen.de/p-anzeige-aufgeben-bestaetigung.html*
 // @homepage      https://github.com/OldRon1977/Kleinanzeigen-Anzeigen-duplizieren
 // @updateURL     https://github.com/OldRon1977/Kleinanzeigen-Anzeigen-duplizieren/raw/main/kleinanzeigen-duplizieren.user.js
 // @downloadURL   https://github.com/OldRon1977/Kleinanzeigen-Anzeigen-duplizieren/raw/main/kleinanzeigen-duplizieren.user.js
@@ -524,6 +529,10 @@
                 // abgesendet wurde. Die Erfolgs-Verifikation laeuft im Helper-Tab,
                 // weil dieser Tab gleich wegnavigiert und sein JS-Context stirbt.
                 batchSetResult(originalId, 'save_clicked:' + (deleteFailed ? 'delete_failed' : 'delete_ok'));
+                // Self-Close-Marker fuer die Bestaetigungs-Seite:
+                // dort liest das Skript ihn aus, schreibt 'ok' ins localStorage
+                // und schliesst den Tab selbst (window.close darf nur der eigene Tab).
+                try { sessionStorage.setItem('ka-batch-close-marker', originalId); } catch (e) {}
             }
             saveBtn.click();
 
@@ -615,6 +624,24 @@
     // === INITIALISIERUNG ===
     function init() {
         logger.log('UserScript initialisiert (v3.5.0)');
+
+        // Wenn wir auf der Bestaetigungs-Seite gelandet sind und ein Batch-Marker
+        // im sessionStorage liegt: Erfolg an Helper signalisieren und Tab schliessen.
+        if (window.location.pathname.indexOf('/p-anzeige-aufgeben-bestaetigung.html') === 0) {
+            try {
+                const origAdId = sessionStorage.getItem('ka-batch-close-marker');
+                if (origAdId) {
+                    sessionStorage.removeItem('ka-batch-close-marker');
+                    logger.log('Bestaetigungs-Seite erreicht, signalisiere ok an Helper', { origAdId: origAdId });
+                    try { localStorage.setItem('ka-batch-result-' + origAdId, 'ok'); } catch (e) {}
+                    // Kurze Verzoegerung, damit Helper das storage-Event verarbeiten kann
+                    setTimeout(function () { try { window.close(); } catch (e) {} }, 500);
+                }
+            } catch (e) {
+                logger.warn('Bestaetigungs-Seite Hook fehlgeschlagen', e);
+            }
+            return;
+        }
 
         // Banner-Blocker sofort injizieren
         injectBannerBlockerStyles();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 ﻿{
   "name": "kleinanzeigen-anzeigen-duplizieren",
-  "version": "3.3.11",
+  "version": "3.5.0",
   "description": "eBay Kleinanzeigen - Anzeige duplizieren / neu einstellen. Einfaches Duplizieren und Smart Neu-Einstellen von Anzeigen mit automatischer Bilderhaltung",
   "main": "kleinanzeigen-duplizieren.user.js",
   "scripts": {


### PR DESCRIPTION
## Zusammenfassung

Neuer Batch-Modus auf "Meine Anzeigen": ein Button stellt alle Anzeigen, die älter als 7 Tage sind, nacheinander mit 3 ± 1 Minuten Pause neu ein. Mit Recovery-Snapshot, Save-Verifikation und Auto-Stop bei Datenverlust.

## Highlights

- **Batch-Modus** im Helper. Confirm-Overlay listet Treffer mit Titel, ID, Restlaufzeit. Start/Abbrechen.
- **Recovery-Snapshot** vor jeder Smart-Republish-Aktion: Form-Felder + Bild-Bytes in IndexedDB. Auto-verworfen bei Erfolg, behalten bei Datenverlust. ZIP-Download im Done-Overlay.
- **Save-Verifikation:** Erfolg wird erst gemeldet, wenn die Bestätigungsseite erreicht wurde (kein vorzeitiges OK).
- **Auto-Stop** bei `save_failed:delete_ok` (Original weg, neue Anzeige nicht entstanden).
- **GM_openInTab** für robustes Schließen des Worker-Tabs nach Navigation. Hauptscript bleibt `@grant none`.
- **Versionsbump:** Hauptscript 3.4.0 → 3.5.0, Helper 1.1.2 → 1.3.0, package.json 3.3.11 → 3.5.0 (Drift korrigiert).

## Per-Anzeige-Button

Der bestehende "Smart neu einstellen"-Button pro Anzeige läuft jetzt durch dieselbe Batch-Worker-Logik. Tab schließt sich nach Erfolg automatisch, Snapshot wird verworfen.

## Verifikation

- Lint ✓ (`node -c`)
- Tests 52/52 ✓ (29 Unit + 23 Integration)
- Manueller Test mit `MIN_DAYS_TO_END = 60` (im Branch zwischenzeitlich gesetzt, vor Merge zurück auf 53):
  - Snapshot wird gespeichert
  - Worker durchläuft Delete + Save
  - Bestätigungsseite triggert `ok` an Helper
  - Helper schließt Worker-Tab via `GM_openInTab.close()`
  - IndexedDB nach Erfolg leer
  - Done-Overlay zeigt OK/Fehler-Zähler

## Doku

README-Changelog (auf Deutsch, ohne Issue-Refs) und IMPROVEMENTS.md ergänzt. Projekt-spezifische Git-Workflow-Steering-Datei unter `.kiro/steering/` hinzugefügt.