### PR TITLE
chore: .gitignore bereinigt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,32 +21,16 @@ Thumbs.db
 *.log
 npm-debug.log*
 
-# Temporary
+# Temporaer
 tmp/
 temp/
 *.tmp
 
-# Security audit documentation (internal only, contains vulnerability details)
-Security-Findings.md
-CRIT-001-SOLUTION.md
+# Lokale Tool-Konfiguration
+.claude/
 
-# Kiro config
-.kiro/settings/
-
-# Projektanweisungen (Claude.ai)
-PROJEKTANWEISUNGEN.md
-
-# Kiro steering (local only)
-.kiro/steering/
-
-# Claude-Agent-Worktrees
-.claude/worktrees/
-
-# Lokale Review-Arbeitsartefakte
+# Interne Arbeitsdokumente (nur lokal halten)
+PROTOCOL.md
 REVIEW.md
 BACKLOG.md
 REVIEW_SUMMARY.md
-PROTOCOL.md
-
-# Lokale Editor-/Tool-Konfiguration
-.claude/


### PR DESCRIPTION
Tote Einträge entfernt (Kiro, alte Audit-Dateinamen, PROJEKTANWEISUNGEN.md, redundante .claude/worktrees/-Zeile). Schutz-Einträge für lokale Arbeitsdokumente und Tool-Konfiguration bleiben.