### PR TITLE
feat(helper): Auswahl im Batch-Bestaetigungs-Overlay (Checkboxen)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,13 @@ Beide Scripts erhalten automatisch Updates über Tampermonkey.
 2. Neben jedem "Bearbeiten"-Link erscheint der Button "Smart neu einstellen"
 3. Ein Klick öffnet die Bearbeiten-Seite und führt die Aktion automatisch aus
 
+### Batch-Modus (Helper ab v1.3.0)
+1. Öffne "Meine Anzeigen" auf kleinanzeigen.de
+2. Über der Anzeigenliste erscheint der Batch-Button
+3. Das Bestätigungs-Overlay listet alle Anzeigen auf, die älter als 7 Tage sind — **alle vorausgewählt**
+4. Ab Helper v1.6.0: Einzelne Anzeigen lassen sich abwählen (Checkbox), z.B. Daueranzeigen wie Dienstleistungen. "Alle" / "Keine" setzen die komplette Auswahl. Zusammenfassung und geschätzte Laufzeit aktualisieren sich mit
+5. **Start** verarbeitet nur die angehakten Anzeigen nacheinander, mit 3 ± 1 Minuten Pause. Vor jeder Löschung wird ein Recovery-Snapshot in IndexedDB abgelegt
+
 ### Banner & Popup-Blocker (ab v3.4.0)
 Das Script blendet automatisch aus:
 - **Kostenpflichtige Feature-Optionen** (Highlight, Galerie, Bumpup) auf der Bearbeiten-Seite
@@ -96,6 +103,13 @@ Hauptscript verwendet `@grant none`. Helper-Script verwendet ab v1.3.0 `@grant G
 - Das Tab-übergreifende Protokoll zwischen Haupt- und Helper-Script (localStorage-Result-Keys, Fehlercodes, IndexedDB-Snapshots) wird durch die Tests in `tests/helper.protocol.test.js` abgesichert; Änderungen daran müssen in beiden Scripts synchron erfolgen.
 
 ## Changelog
+
+### Helper 1.6.0 (Juli 2026)
+
+- **Neu**: Auswahl im Batch-Bestätigungs-Overlay. Jeder Treffer hat eine Checkbox (standardmäßig angehakt), dazu "Alle"/"Keine". Gestartet wird nur mit den ausgewählten Anzeigen — Daueranzeigen lassen sich so vom Batch ausnehmen, ohne den Schwellwert zu ändern.
+- **Neu**: Zusammenfassung und Laufzeitschätzung aktualisieren sich live ("3 von 8 ausgewählt"); der Start-Button ist gesperrt, solange nichts ausgewählt ist.
+- **Fix**: Die Laufzeitschätzung zählt die Pausen *zwischen* den Anzeigen statt einer Pause pro Anzeige — nach der letzten Anzeige wird nicht mehr gewartet (8 Anzeigen: 21 statt 24 Minuten).
+- **Tests**: `estimateRuntimeMinutes` als reine Funktion herausgezogen und getestet; neue jsdom-Suite `helper.confirm.dom.test.js` prüft das Overlay gegen den echten Produktivcode (Vorauswahl, Abwählen, Alle/Keine, gesperrter Start).
 
 ### Version 3.6.0 / Helper 1.4.0 (Juli 2026)
 

--- a/helper.user.js
+++ b/helper.user.js
@@ -5,7 +5,7 @@
 // @icon          https://www.kleinanzeigen.de/favicon.ico
 // @copyright     2026
 // @license       MIT
-// @version       1.5.0
+// @version       1.6.0
 // @author        panzli (Original), OldRon1977 (Anpassungen)
 // @match         https://www.kleinanzeigen.de/m-meine-anzeigen.html*
 // @homepage      https://github.com/OldRon1977/Kleinanzeigen-Anzeigen-duplizieren
@@ -565,10 +565,15 @@
         parent.appendChild(sec);
     }
 
+    // Geschaetzte Batch-Laufzeit in Minuten. Zwischen zwei Anzeigen liegt eine
+    // Pause von DELAY_BASE_MS; nach der letzten Anzeige wird nicht mehr gewartet.
+    function estimateRuntimeMinutes(count) {
+        if (count <= 0) return 0;
+        return Math.round((count - 1) * DELAY_BASE_MS / 60000);
+    }
+
     async function renderConfirm(matches, skipped, onStart) {
         const overlay = ensureOverlay();
-        const totalMs = matches.length * (DELAY_BASE_MS);
-        const minutes = Math.round(totalMs / 60000);
 
         overlay.innerHTML = '';
 
@@ -597,34 +602,72 @@
             } catch (e) { warn('Recovery-Listing fehlgeschlagen', e); }
             return;
         }
+        // Auswahl: standardmaessig sind alle Treffer angehakt. Einzelne Anzeigen
+        // lassen sich abwaehlen (z.B. Daueranzeigen, die nicht erneuert werden
+        // sollen); gestartet wird nur mit den angehakten Eintraegen.
+        const selected = new Set(matches.map(function (m) { return m.adId; }));
+        const checkboxes = [];
+
         const line1 = document.createElement('div');
-        const strong = document.createElement('strong');
-        strong.textContent = matches.length;
-        line1.appendChild(strong);
-        line1.appendChild(document.createTextNode(' Anzeige(n) werden bearbeitet.'));
         summary.appendChild(line1);
         const line2 = document.createElement('div');
         line2.style.cssText = 'color:#666;margin-top:4px;';
-        line2.textContent = 'Geschätzte Laufzeit: ca. ' + minutes + ' Minuten (3 ± 1 min Pause pro Anzeige).';
         summary.appendChild(line2);
         overlay.appendChild(summary);
 
-        const list = document.createElement('ol');
-        list.style.cssText = 'margin:0;padding:8px 14px 8px 32px;max-height:240px;overflow-y:auto;';
+        const list = document.createElement('ul');
+        list.style.cssText = 'margin:0;padding:8px 14px;max-height:240px;overflow-y:auto;list-style:none;';
         matches.forEach(function (m) {
             const li = document.createElement('li');
             li.style.cssText = 'margin:4px 0;line-height:1.3;';
+
+            const label = document.createElement('label');
+            label.style.cssText = 'display:flex;gap:8px;align-items:flex-start;cursor:pointer;';
+
+            const cb = document.createElement('input');
+            cb.type = 'checkbox';
+            cb.checked = true;
+            cb.style.cssText = 'margin-top:2px;flex:none;cursor:pointer;';
+            cb.onchange = function () {
+                if (cb.checked) selected.add(m.adId);
+                else selected.delete(m.adId);
+                updateSummary();
+            };
+            checkboxes.push(cb);
+
+            const texts = document.createElement('div');
             const t = document.createElement('div');
             t.style.cssText = 'font-weight:500;';
             t.textContent = m.title;
             const meta = document.createElement('div');
             meta.style.cssText = 'color:#666;font-size:12px;';
             meta.textContent = 'ID ' + m.adId + ' \u00B7 endet ' + m.endText + ' (' + m.daysLeft + ' Tage)';
-            li.appendChild(t);
-            li.appendChild(meta);
+            texts.appendChild(t);
+            texts.appendChild(meta);
+
+            label.appendChild(cb);
+            label.appendChild(texts);
+            li.appendChild(label);
             list.appendChild(li);
         });
         overlay.appendChild(list);
+
+        const bulk = document.createElement('div');
+        bulk.style.cssText = 'padding:0 14px 8px;display:flex;gap:12px;font-size:12px;';
+        [['Alle', true], ['Keine', false]].forEach(function (pair) {
+            const b = document.createElement('button');
+            b.type = 'button';
+            b.textContent = pair[0];
+            b.style.cssText = 'background:none;border:none;padding:0;color:#007bff;cursor:pointer;font-size:12px;text-decoration:underline;';
+            b.onclick = function () {
+                checkboxes.forEach(function (c) { c.checked = pair[1]; });
+                selected.clear();
+                if (pair[1]) matches.forEach(function (m) { selected.add(m.adId); });
+                updateSummary();
+            };
+            bulk.appendChild(b);
+        });
+        overlay.appendChild(bulk);
 
         if (skipped.length > 0) {
             const sk = document.createElement('div');
@@ -644,10 +687,31 @@
         const cancel = makeButton('Abbrechen', false);
         cancel.onclick = closeOverlay;
         const start = makeButton('Start', true);
-        start.onclick = function () { onStart(matches); };
+        start.onclick = function () {
+            const chosen = matches.filter(function (m) { return selected.has(m.adId); });
+            if (!chosen.length) return;
+            onStart(chosen);
+        };
         actions.appendChild(cancel);
         actions.appendChild(start);
         overlay.appendChild(actions);
+
+        // Haelt Zusammenfassung und Start-Button im Einklang mit der Auswahl.
+        function updateSummary() {
+            const count = selected.size;
+            line1.textContent = '';
+            const strong = document.createElement('strong');
+            strong.textContent = count;
+            line1.appendChild(strong);
+            line1.appendChild(document.createTextNode(' von ' + matches.length + ' Anzeige(n) ausgewählt.'));
+            line2.textContent = count > 0
+                ? 'Geschätzte Laufzeit: ca. ' + estimateRuntimeMinutes(count) + ' Minuten (3 ± 1 min Pause pro Anzeige).'
+                : 'Keine Anzeige ausgewählt.';
+            start.disabled = (count === 0);
+            start.style.opacity = count === 0 ? '0.5' : '1';
+            start.style.cursor = count === 0 ? 'not-allowed' : 'pointer';
+        }
+        updateSummary();
     }
 
     function renderProgress(state, onStop) {
@@ -991,6 +1055,8 @@
             MIN_DAYS_TO_END,
             parseEndDate,
             daysUntil,
+            estimateRuntimeMinutes,
+            renderConfirm,
             jitterDelay,
             sanitize,
             crc32,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kleinanzeigen-anzeigen-duplizieren",
   "version": "3.7.0",
-  "helperVersion": "1.5.0",
+  "helperVersion": "1.6.0",
   "description": "eBay Kleinanzeigen - Anzeige duplizieren / neu einstellen. Einfaches Duplizieren und Smart Neu-Einstellen von Anzeigen mit automatischer Bilderhaltung",
   "main": "kleinanzeigen-duplizieren.user.js",
   "scripts": {

--- a/tests/helper.confirm.dom.test.js
+++ b/tests/helper.confirm.dom.test.js
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import helper from '../helper.user.js';
+
+const { renderConfirm } = helper;
+
+const MATCHES = [
+    { adId: '1001', title: 'Fahrrad', endText: '12.09.2026', daysLeft: 48 },
+    { adId: '1002', title: 'Buerostuhl', endText: '10.09.2026', daysLeft: 46 },
+    { adId: '1003', title: 'Hecke schneiden', endText: '05.09.2026', daysLeft: 41 }
+];
+
+// renderConfirm ruft listSnapshotMeta() -> indexedDB auf. In jsdom existiert
+// kein indexedDB; der Aufruf ist im Produktivcode in try/catch gekapselt und
+// die Recovery-Section entfaellt dann einfach.
+function overlay() {
+    return document.getElementById('ka-batch-overlay');
+}
+
+function checkboxes() {
+    return Array.from(overlay().querySelectorAll('input[type="checkbox"]'));
+}
+
+function buttonByText(text) {
+    return Array.from(overlay().querySelectorAll('button'))
+        .find((b) => b.textContent === text);
+}
+
+function summaryText() {
+    return overlay().textContent;
+}
+
+beforeEach(() => {
+    document.body.innerHTML = '';
+});
+
+describe('renderConfirm – Auswahl', () => {
+    it('hakt alle Treffer standardmaessig an', async () => {
+        await renderConfirm(MATCHES, [], () => {});
+        const cbs = checkboxes();
+        expect(cbs).toHaveLength(3);
+        expect(cbs.every((c) => c.checked)).toBe(true);
+        expect(summaryText()).toContain('3 von 3');
+    });
+
+    it('startet nur mit den angehakten Anzeigen', async () => {
+        let started = null;
+        await renderConfirm(MATCHES, [], (chosen) => { started = chosen; });
+
+        checkboxes()[2].checked = false;
+        checkboxes()[2].onchange();
+
+        expect(summaryText()).toContain('2 von 3');
+        buttonByText('Start').click();
+
+        expect(started.map((m) => m.adId)).toEqual(['1001', '1002']);
+    });
+
+    it('sperrt Start, wenn nichts ausgewaehlt ist', async () => {
+        let started = null;
+        await renderConfirm(MATCHES, [], (chosen) => { started = chosen; });
+
+        buttonByText('Keine').click();
+
+        expect(checkboxes().every((c) => !c.checked)).toBe(true);
+        expect(buttonByText('Start').disabled).toBe(true);
+
+        buttonByText('Start').click();
+        expect(started).toBeNull();
+    });
+
+    it('stellt mit "Alle" die vollstaendige Auswahl wieder her', async () => {
+        let started = null;
+        await renderConfirm(MATCHES, [], (chosen) => { started = chosen; });
+
+        buttonByText('Keine').click();
+        buttonByText('Alle').click();
+
+        expect(checkboxes().every((c) => c.checked)).toBe(true);
+        expect(summaryText()).toContain('3 von 3');
+
+        buttonByText('Start').click();
+        expect(started).toHaveLength(3);
+    });
+
+    it('zeigt Treffer mit Titel, ID und Enddatum an', async () => {
+        await renderConfirm(MATCHES, [], () => {});
+        const text = summaryText();
+        expect(text).toContain('Hecke schneiden');
+        expect(text).toContain('ID 1003');
+        expect(text).toContain('05.09.2026');
+    });
+});

--- a/tests/helper.logic.test.js
+++ b/tests/helper.logic.test.js
@@ -5,6 +5,7 @@ const {
     MIN_DAYS_TO_END,
     parseEndDate,
     daysUntil,
+    estimateRuntimeMinutes,
     jitterDelay,
     sanitize,
     crc32,
@@ -59,6 +60,25 @@ describe('daysUntil', () => {
 
     it('MIN_DAYS_TO_END ist der dokumentierte Schwellwert 53', () => {
         expect(MIN_DAYS_TO_END).toBe(53);
+    });
+});
+
+describe('estimateRuntimeMinutes', () => {
+    it('liefert 0 fuer leere Auswahl', () => {
+        expect(estimateRuntimeMinutes(0)).toBe(0);
+    });
+
+    it('liefert 0 fuer eine einzelne Anzeige (keine Pause danach)', () => {
+        expect(estimateRuntimeMinutes(1)).toBe(0);
+    });
+
+    it('rechnet die Pausen ZWISCHEN den Anzeigen', () => {
+        expect(estimateRuntimeMinutes(2)).toBe(3);   // 1 Pause
+        expect(estimateRuntimeMinutes(8)).toBe(21);  // 7 Pausen
+    });
+
+    it('liefert 0 fuer negative Werte', () => {
+        expect(estimateRuntimeMinutes(-3)).toBe(0);
     });
 });
 


### PR DESCRIPTION
Der Batch verarbeitete bisher zwingend alle Anzeigen, die aelter als 7 Tage sind. Wer eine einzelne Anzeige ausnehmen wollte (z.B. eine Daueranzeige fuer eine Dienstleistung), musste den Batch komplett meiden und jede Anzeige einzeln neu einstellen.

Das Bestaetigungs-Overlay bekommt daher pro Treffer eine Checkbox, standardmaessig angehakt -- der bisherige Ablauf (Start = alles) bleibt also ein Klick. Dazu "Alle"/"Keine" fuer die komplette Auswahl, eine mitlaufende Zusammenfassung ("3 von 8 ausgewaehlt") und ein gesperrter Start-Button bei leerer Auswahl.

Nebenbei korrigiert: Die Laufzeitschaetzung zaehlte eine Pause pro Anzeige, obwohl nach der letzten Anzeige nicht mehr gewartet wird. Die Logik steckt jetzt in der reinen Funktion estimateRuntimeMinutes(count) und ist getestet.

Tests: neue jsdom-Suite tests/helper.confirm.dom.test.js prueft renderConfirm gegen den echten Produktivcode (Vorauswahl, Abwaehlen, Alle/Keine, gesperrter Start, Trefferdarstellung). 41 Tests gruen, Syntax-Check gruen.