### PR TITLE
fix(duplicate): adId-Feld namensunabhaengig aufloesen (v3.7.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,18 @@ Hauptscript verwendet `@grant none`. Helper-Script verwendet ab v1.3.0 `@grant G
 
 ## Changelog
 
+### Version 3.7.1 (August 2026)
+
+- **Fix**: Das versteckte Ad-ID-Feld wird jetzt auch dann gefunden, wenn Kleinanzeigen es umbenennt. Greifen die bekannten Selektoren nicht, wird namensunabhängig das Hidden-Feld gesucht, dessen Wert exakt der `adId` aus der URL entspricht — auf der Bearbeiten-Seite ist dieser Treffer eindeutig. Bleibt er mehrdeutig, wird weiterhin abgebrochen statt geraten. (Issue #49)
+- **Fix (Diagnose)**: Bricht die Auflösung trotzdem ab, protokolliert das Script eine Bestandsaufnahme der vorhandenen Hidden-Felder (nur Feldnamen und Wertlängen, keine Inhalte) — ohne diese Angaben ist von außen nicht unterscheidbar, ob das Feld umbenannt wurde oder fehlt. (Issue #49)
+- **Hinweis**: Der harte Abbruch bei fehlendem Feld bleibt bestehen. Er ist nicht die Ursache des Fehlers, sondern macht ihn sichtbar: ohne Neutralisierung würde der Submit das Original überschreiben statt eine Kopie anzulegen.
+
+### Version 3.7.0 / Helper 1.5.0 (Juli 2026)
+
+- **Neu**: "Duplizieren"-Button direkt auf "Meine Anzeigen" — dupliziert eine Anzeige ohne Umweg über die Bearbeiten-Seite; das Original bleibt erhalten, es wird nichts gelöscht. (Issue #46)
+- **Fix**: Endloser Spinner beim Auto-Trigger via `#duplicate`. Der Klick auf "Anzeige speichern" wartet jetzt auf das vollständige Laden der Seite — vorher konnte er verpuffen, solange die Form noch nicht hydratisiert war.
+- **Neu**: Der Worker-Tab schließt sich nach erfolgreicher Duplizierung selbst (Signal über die Bestätigungs-Seite an den Helper).
+
 ### Version 3.6.0 / Helper 1.4.0 (Juli 2026)
 
 Ergebnis eines vollständigen Code-Reviews (14 Findings). Alle Änderungen sind Härtungen bestehender Abläufe — keine neuen Features, Happy Path unverändert.

--- a/kleinanzeigen-duplizieren.user.js
+++ b/kleinanzeigen-duplizieren.user.js
@@ -5,7 +5,7 @@
 // @icon          https://www.kleinanzeigen.de/favicon.ico
 // @copyright     2026
 // @license       MIT
-// @version       3.7.0
+// @version       3.7.1
 // @author        OldRon1977 (Improvements), J05HI (Original)
 // @credits       Basierend auf dem Original-Script von J05HI (https://gist.github.com/J05HI/9f3fc7a496e8baeff5a56e0c1a710bb5)
 // @match         https://www.kleinanzeigen.de/p-anzeige-bearbeiten.html*
@@ -35,7 +35,7 @@
 (function () {
     'use strict';
 
-    const SCRIPT_VERSION = '3.7.0'; // wird von scripts/build.js synchron zu package.json gehalten
+    const SCRIPT_VERSION = '3.7.1'; // wird von scripts/build.js synchron zu package.json gehalten
 
     // === KONSTANTEN ===
     const CONFIG = {
@@ -325,6 +325,62 @@
         );
     }
 
+    // Bekannte Namen/IDs des versteckten Ad-ID-Felds. Kleinanzeigen hat den
+    // Feldnamen historisch schon zweimal geaendert (#postad-id -> name="id"
+    // -> name="adId"), deshalb ist die Liste kumulativ.
+    const AD_ID_SELECTOR = 'input[name="adId"], #postad-id, input[name="postad-id"], input[name="id"]';
+
+    function getUrlAdId(loc) {
+        const search = (loc || window.location).search || '';
+        const m = search.match(/adId=(\d+)/);
+        return m ? m[1] : null;
+    }
+
+    /**
+     * Loest das versteckte Ad-ID-Feld auf.
+     *
+     * Primaer ueber die bekannten Selektoren. Greift keiner, wird
+     * namensunabhaengig das Input gesucht, dessen Wert exakt der adId aus der
+     * URL entspricht -- auf der Bearbeiten-Seite ist dieser Treffer eindeutig,
+     * weil der Wert die ID der gerade bearbeiteten Anzeige ist. Damit ueberlebt
+     * die Aufloesung eine weitere Umbenennung des Feldnamens (Issue #49).
+     *
+     * Bleibt der Treffer mehrdeutig, wird bewusst null geliefert: lieber
+     * abbrechen als das falsche Feld neutralisieren.
+     */
+    function findAdIdInput(doc, urlAdId) {
+        const direct = doc.querySelector(AD_ID_SELECTOR);
+        if (direct) return direct;
+        if (!urlAdId) return null;
+
+        // Bewusst nur Hidden-Felder: das Ad-ID-Feld war in jeder bisherigen
+        // Variante versteckt. Ein sichtbares Feld mit zufaellig gleichem Wert
+        // (etwa ein Titel, der nur aus der ID besteht) wuerde durch die
+        // Neutralisierung geleert -- die Kopie waere beschaedigt.
+        const candidates = Array.from(doc.querySelectorAll('input[type="hidden"]'))
+            .filter(function (i) { return i.value === urlAdId; });
+        return candidates.length === 1 ? candidates[0] : null;
+    }
+
+    /**
+     * Bestandsaufnahme fuer den Abbruch-Fall. Ohne die Feldnamen aus der
+     * betroffenen Umgebung ist nicht entscheidbar, ob das Feld nur umbenannt
+     * wurde oder ganz fehlt (Issue #49) -- die Ausgabe ist bewusst so knapp,
+     * dass sie gefahrlos in ein Issue kopiert werden kann: nur Feldnamen und
+     * Wertlaengen, keine Feldinhalte.
+     */
+    function describeAdIdLookup(doc, urlAdId) {
+        return {
+            urlAdId: urlAdId ? 'vorhanden' : 'fehlt',
+            speichernButton: !!Array.from(doc.querySelectorAll('button')).find(
+                function (b) { return b.textContent.trim().indexOf('Anzeige speichern') === 0; }
+            ),
+            inputs: doc.querySelectorAll('input').length,
+            hiddenFelder: Array.from(doc.querySelectorAll('input[type="hidden"]'))
+                .map(function (i) { return (i.name || i.id || '(ohne name)') + ':' + (i.value || '').length; })
+        };
+    }
+
     function waitForElement(finderFn, timeoutMs) {
         return new Promise(function (resolve) {
             const el = finderFn();
@@ -373,18 +429,20 @@
             logger.log('Starte Duplikat-Prozess');
             showLoadingSpinner();
 
-            const adIdSelector = 'input[name="adId"], #postad-id, input[name="postad-id"]';
+            const urlAdId = getUrlAdId();
             let saveBtn = await waitForElement(findSaveButton, 10000);
             if (!saveBtn) throw new Error('Speichern-Button nicht gefunden (Timeout)');
 
             let adIdInput = await waitForElement(
-                () => document.querySelector(adIdSelector),
+                () => findAdIdInput(document, urlAdId),
                 10000
             );
             // Harter Abbruch, wenn das adId-Feld nicht auffindbar ist: ohne
             // Neutralisierung haette der Submit Bearbeiten- statt Neuanlage-
             // Semantik. Der catch-Block raeumt UI und Buttons auf.
             if (!adIdInput) {
+                logger.error('adId-Feld nicht auffindbar - Bestandsaufnahme fuer Issue-Meldung',
+                    describeAdIdLookup(document, urlAdId));
                 throw new Error('adId-Feld nicht gefunden - Abbruch, um versehentliches Bearbeiten zu verhindern');
             }
 
@@ -402,7 +460,7 @@
                 saveBtn = await waitForElement(findSaveButton, 5000);
             }
             if (!adIdInput.isConnected) {
-                adIdInput = await waitForElement(() => document.querySelector(adIdSelector), 5000);
+                adIdInput = await waitForElement(() => findAdIdInput(document, urlAdId), 5000);
             }
             if (!saveBtn || !adIdInput) {
                 throw new Error('Formular nach Laden nicht auffindbar - Abbruch, um versehentliches Bearbeiten zu verhindern');
@@ -423,11 +481,8 @@
             // On-Page-Modus (Button direkt auf der Bearbeiten-Seite) bleibt der
             // Tab bewusst offen -- es gibt keinen Helper, der ihn schliessen soll,
             // und es waere der Haupt-Tab des Users.
-            if (window.location.hash === '#duplicate') {
-                const dupMatch = window.location.search.match(/adId=(\d+)/);
-                if (dupMatch) {
-                    try { sessionStorage.setItem('ka-duplicate-adid', dupMatch[1]); } catch (e) {}
-                }
+            if (window.location.hash === '#duplicate' && urlAdId) {
+                try { sessionStorage.setItem('ka-duplicate-adid', urlAdId); } catch (e) {}
             }
 
             // Popup-Dismisser starten bevor wir klicken
@@ -567,8 +622,7 @@
     }
 
     async function smartRepublish() {
-        const urlMatch = window.location.search.match(/adId=(\d+)/);
-        const originalId = urlMatch ? urlMatch[1] : null;
+        const originalId = getUrlAdId();
         const batchMode = isBatchMode();
         // Lifecycle-Marker fuer differenzierte Fehlerklassifikation:
         // wenn nach erfolgreichem Delete etwas schief geht, ist das Datenverlust.
@@ -585,15 +639,18 @@
             // wird OHNE Loeschung abgebrochen - so kann das Original nicht verloren
             // gehen, wenn die Seite den Neuanlage-Submit gar nicht durchfuehren
             // koennte.
-            const adIdSelector = 'input[name="adId"], #postad-id, input[name="postad-id"]';
             let saveBtn = await waitForElement(findSaveButton, 10000);
             let adIdInput = await waitForElement(
-                () => document.querySelector(adIdSelector),
+                () => findAdIdInput(document, originalId),
                 10000
             );
             if (!saveBtn || !adIdInput) {
                 const missing = !saveBtn ? 'save_button_missing' : 'adid_input_missing';
                 logger.error('Preflight fehlgeschlagen, Abbruch vor Loeschung', { missing: missing });
+                if (!adIdInput) {
+                    logger.error('adId-Feld nicht auffindbar - Bestandsaufnahme fuer Issue-Meldung',
+                        describeAdIdLookup(document, originalId));
+                }
                 showNotification('Voraussetzung fehlt (' + missing + ') - Abbruch, Original bleibt erhalten.', 'error');
                 showLoadingSpinner(false);
                 document.querySelectorAll('.ka-duplicate-btn, .ka-smart-btn').forEach(btn => btn.disabled = false);
@@ -654,7 +711,7 @@
                 saveBtn = await waitForElement(findSaveButton, 5000);
             }
             if (!adIdInput.isConnected) {
-                adIdInput = await waitForElement(() => document.querySelector(adIdSelector), 5000);
+                adIdInput = await waitForElement(() => findAdIdInput(document, originalId), 5000);
             }
             if (!saveBtn || !adIdInput) {
                 logger.error('Referenzen nach Loeschung nicht mehr aufloesbar', { deleteFailed: deleteFailed });
@@ -872,7 +929,10 @@
     // das Script nicht versehentlich deaktivieren kann.
     if (typeof module !== 'undefined' && module.exports &&
         typeof process !== 'undefined' && process.versions && process.versions.node) {
-        module.exports = { CONFIG, getExponentialBackoffWait, readFormFields, collectImageUrls };
+        module.exports = {
+            CONFIG, getExponentialBackoffWait, readFormFields, collectImageUrls,
+            findAdIdInput, describeAdIdLookup, getUrlAdId
+        };
         return; // im Test-Kontext keine Initialisierung/Timer
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kleinanzeigen-anzeigen-duplizieren",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "helperVersion": "1.5.0",
   "description": "eBay Kleinanzeigen - Anzeige duplizieren / neu einstellen. Einfaches Duplizieren und Smart Neu-Einstellen von Anzeigen mit automatischer Bilderhaltung",
   "main": "kleinanzeigen-duplizieren.user.js",

--- a/tests/worker.adid.test.js
+++ b/tests/worker.adid.test.js
@@ -1,0 +1,117 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import worker from '../kleinanzeigen-duplizieren.user.js';
+
+const { findAdIdInput, describeAdIdLookup, getUrlAdId } = worker;
+
+const AD_ID = '3485590892';
+
+beforeEach(() => {
+    document.body.innerHTML = '';
+});
+
+describe('getUrlAdId', () => {
+    it('liest die adId aus der Query', () => {
+        expect(getUrlAdId({ search: '?adId=3485590892' })).toBe(AD_ID);
+    });
+
+    it('liefert null ohne adId', () => {
+        expect(getUrlAdId({ search: '?foo=1' })).toBeNull();
+        expect(getUrlAdId({ search: '' })).toBeNull();
+    });
+});
+
+describe('findAdIdInput - bekannte Selektoren', () => {
+    it('findet input[name="adId"] (aktuelles Markup)', () => {
+        document.body.innerHTML = `
+            <form>
+                <input type="hidden" name="categoryId" value="225">
+                <input type="hidden" name="adId" value="${AD_ID}">
+            </form>
+        `;
+        const el = findAdIdInput(document, AD_ID);
+        expect(el).not.toBeNull();
+        expect(el.name).toBe('adId');
+    });
+
+    it('findet die historischen Varianten #postad-id / name="id"', () => {
+        document.body.innerHTML = `<form><input type="hidden" id="postad-id" value="${AD_ID}"></form>`;
+        expect(findAdIdInput(document, AD_ID).id).toBe('postad-id');
+
+        document.body.innerHTML = `<form><input type="hidden" name="id" value="${AD_ID}"></form>`;
+        expect(findAdIdInput(document, AD_ID).name).toBe('id');
+    });
+
+    it('greift auch ohne adId in der URL, solange der Selektor trifft', () => {
+        document.body.innerHTML = `<form><input type="hidden" name="adId" value="${AD_ID}"></form>`;
+        expect(findAdIdInput(document, null)).not.toBeNull();
+    });
+});
+
+describe('findAdIdInput - Fallback ueber den Feldwert (Issue #49)', () => {
+    it('findet ein umbenanntes Hidden-Feld anhand der adId aus der URL', () => {
+        document.body.innerHTML = `
+            <form>
+                <input type="hidden" name="categoryId" value="225">
+                <input type="hidden" name="voellig-neuer-name" value="${AD_ID}">
+                <input type="hidden" name="_csrf" value="token">
+            </form>
+        `;
+        const el = findAdIdInput(document, AD_ID);
+        expect(el).not.toBeNull();
+        expect(el.name).toBe('voellig-neuer-name');
+    });
+
+    it('bricht bei Mehrdeutigkeit ab statt zu raten', () => {
+        document.body.innerHTML = `
+            <form>
+                <input type="hidden" name="a" value="${AD_ID}">
+                <input type="hidden" name="b" value="${AD_ID}">
+            </form>
+        `;
+        expect(findAdIdInput(document, AD_ID)).toBeNull();
+    });
+
+    it('fasst sichtbare Felder mit gleichem Wert nicht an', () => {
+        document.body.innerHTML = `<form><input type="text" name="title" value="${AD_ID}"></form>`;
+        expect(findAdIdInput(document, AD_ID)).toBeNull();
+    });
+
+    it('liefert null, wenn weder Selektor noch Wert treffen', () => {
+        document.body.innerHTML = `<form><input type="hidden" name="categoryId" value="225"></form>`;
+        expect(findAdIdInput(document, AD_ID)).toBeNull();
+    });
+
+    it('liefert null ohne adId in der URL', () => {
+        document.body.innerHTML = `<form><input type="hidden" name="unbekannt" value="${AD_ID}"></form>`;
+        expect(findAdIdInput(document, null)).toBeNull();
+    });
+});
+
+describe('describeAdIdLookup', () => {
+    it('meldet Feldnamen und Wertlaengen, aber keine Feldinhalte', () => {
+        document.body.innerHTML = `
+            <form>
+                <input type="hidden" name="_csrf" value="geheimes-token">
+                <input type="text" name="title" value="Mein Titel">
+                <button>Anzeige speichern</button>
+            </form>
+        `;
+        const info = describeAdIdLookup(document, AD_ID);
+
+        expect(info.speichernButton).toBe(true);
+        expect(info.urlAdId).toBe('vorhanden');
+        expect(info.inputs).toBe(2);
+        expect(info.hiddenFelder).toEqual(['_csrf:14']);
+
+        // Keine Werte in der Ausgabe - sie ist zum Kopieren in Issues gedacht.
+        expect(JSON.stringify(info)).not.toContain('geheimes-token');
+        expect(JSON.stringify(info)).not.toContain('Mein Titel');
+    });
+
+    it('meldet einen fehlenden Speichern-Button', () => {
+        document.body.innerHTML = `<form><input type="hidden" name="adId" value="${AD_ID}"></form>`;
+        const info = describeAdIdLookup(document, null);
+        expect(info.speichernButton).toBe(false);
+        expect(info.urlAdId).toBe('fehlt');
+    });
+});


### PR DESCRIPTION
Behebt den in Issue #49 gemeldeten Abbruch `adId-Feld nicht gefunden` (Referenz, kein Auto-Close — die Ursache beim Melder ist noch nicht bestätigt).

## Analyse

Live gegen kleinanzeigen.de geprüft (eingeloggter Account, 4 Anzeigen, 2 Kategorien):

- `input[name="adId"]` ist **vorhanden** — hidden, im Form, Wert = `adId` aus der URL. Der Selektor ist also nicht generell veraltet.
- Das Feld erscheint bei **109 ms**, zeitgleich mit dem Speichern-Button und *vor* `DOMContentLoaded` (231 ms) — es kommt serverseitig im HTML, nicht per React-Nachrendern. Ein Timing-Race scheidet damit aus: ist der Button da, ist das Feld auch da.
- 4/4 Anzeigen mit Feld, `FIXED` wie `NEGOTIABLE`, alle `PRIVATE`.

Beim Melder wurde der Button gefunden, das Feld nicht — auf derselben Seite ist das nur möglich, wenn sein Server anderes Markup ausliefert (die Seite fährt sichtbar A/B-Buckets). Nicht reproduzierbar, deshalb deckt dieser PR beide möglichen Ursachen ab.

## Änderungen

**1. Namensunabhängiger Fallback.** Greifen die bekannten Selektoren nicht, wird das Hidden-Feld gesucht, dessen Wert exakt der `adId` aus der URL entspricht — auf der Bearbeiten-Seite eindeutig. Deckt den Fall „Feld umbenannt" ab; der Selektor musste historisch schon zweimal nachgezogen werden (`#postad-id` → `name="id"` → `name="adId"`).

Bewusst eng gefasst: nur Hidden-Felder (ein sichtbares Feld mit zufällig gleichem Wert würde durch die Neutralisierung geleert und die Kopie beschädigen) und nur bei genau einem Treffer (bei Mehrdeutigkeit ist Abbrechen besser als Raten).

**2. Diagnose beim Abbruch.** Bricht die Auflösung trotzdem ab, werden die vorhandenen Hidden-Felder protokolliert — nur Feldnamen und Wertlängen, keine Inhalte, damit die Ausgabe gefahrlos in ein Issue kopiert werden kann. Deckt den Fall „Feld fehlt ganz" ab: ohne diese Liste ist von außen nicht entscheidbar, welcher der beiden Fälle vorliegt.

Der harte Abbruch bleibt. Er ist nicht die Ursache, sondern macht den Defekt sichtbar — ohne Neutralisierung würde der Submit das Original überschreiben statt eine Kopie anzulegen. In ≤ 3.5.x wäre derselbe Zustand still danebengegangen.

## Verifikation

Live gegen die echte Bearbeiten-Seite, mit dem Code aus der Datei (keine Nachbildung), read-only — nichts geklickt, gespeichert oder gelöscht:

| Szenario | Erwartet | Ergebnis |
|---|---|---|
| Normalfall | findet `name="adId"` | ✅ |
| Feld umbenannt | findet dasselbe Element über den Wert | ✅ |
| Zwei Felder mit gleichem Wert | kein Treffer statt raten | ✅ |
| Feld entfernt | kein Treffer + Diagnose-Ausgabe | ✅ |

Dazu 12 neue Unit-Tests (jsdom), Suite gesamt **44 grün**; `npm run validate` sauber.

## Version

3.7.0 → **3.7.1** (Patch, Helper unverändert bei 1.5.0). Changelog ergänzt — inkl. des bisher fehlenden 3.7.0-Eintrags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)