### PR TITLE
chore(duplicate): Aufloesungsweg des adId-Felds protokollieren (v3.7.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,10 @@ Hauptscript verwendet `@grant none`. Helper-Script verwendet ab v1.3.0 `@grant G
 
 ## Changelog
 
+### Version 3.7.2 (August 2026)
+
+- **Diagnose**: Das Log weist jetzt aus, ob das Ad-ID-Feld über einen bekannten Selektor oder über den Fallback (Feldwert) gefunden wurde. Greift nur noch der Fallback, hat Kleinanzeigen das Feld umbenannt — das steht dann als Warnung samt neuem Feldnamen in der Konsole, statt erst beim nächsten Bruch aufzufallen.
+
 ### Version 3.7.1 (August 2026)
 
 - **Fix**: Das versteckte Ad-ID-Feld wird jetzt auch dann gefunden, wenn Kleinanzeigen es umbenennt. Greifen die bekannten Selektoren nicht, wird namensunabhängig das Hidden-Feld gesucht, dessen Wert exakt der `adId` aus der URL entspricht — auf der Bearbeiten-Seite ist dieser Treffer eindeutig. Bleibt er mehrdeutig, wird weiterhin abgebrochen statt geraten. (Issue #49)

--- a/kleinanzeigen-duplizieren.user.js
+++ b/kleinanzeigen-duplizieren.user.js
@@ -5,7 +5,7 @@
 // @icon          https://www.kleinanzeigen.de/favicon.ico
 // @copyright     2026
 // @license       MIT
-// @version       3.7.1
+// @version       3.7.2
 // @author        OldRon1977 (Improvements), J05HI (Original)
 // @credits       Basierend auf dem Original-Script von J05HI (https://gist.github.com/J05HI/9f3fc7a496e8baeff5a56e0c1a710bb5)
 // @match         https://www.kleinanzeigen.de/p-anzeige-bearbeiten.html*
@@ -35,7 +35,7 @@
 (function () {
     'use strict';
 
-    const SCRIPT_VERSION = '3.7.1'; // wird von scripts/build.js synchron zu package.json gehalten
+    const SCRIPT_VERSION = '3.7.2'; // wird von scripts/build.js synchron zu package.json gehalten
 
     // === KONSTANTEN ===
     const CONFIG = {
@@ -363,6 +363,35 @@
     }
 
     /**
+     * Beschreibt, ueber welchen Weg ein Feld aufgeloest wurde. Muss VOR der
+     * Neutralisierung aufgerufen werden -- das Entfernen des name-Attributs
+     * veraendert das Selektor-Matching.
+     *
+     * Ein Treffer per Fallback bedeutet: Kleinanzeigen hat den Feldnamen
+     * geaendert. Das soll im Log stehen, bevor der naechste Selektor-Bruch
+     * kommt -- sonst ist aus einem erfolgreichen Lauf nicht ablesbar, dass die
+     * bekannten Selektoren nicht mehr greifen (Issue #49).
+     */
+    function describeAdIdResolution(el) {
+        const perSelektor = el.matches(AD_ID_SELECTOR);
+        return {
+            weg: perSelektor ? 'bekannter Selektor' : 'Fallback ueber Feldwert',
+            feldName: el.name || el.id || '(ohne name)',
+            selektorVeraltet: !perSelektor
+        };
+    }
+
+    function logAdIdResolution(el) {
+        const info = describeAdIdResolution(el);
+        logger.log('adId-Feld aufgeloest', info);
+        if (info.selektorVeraltet) {
+            logger.warn('Bekannte adId-Selektoren greifen nicht mehr, Feld heisst jetzt "' +
+                info.feldName + '" - bitte im Repository melden');
+        }
+        return info;
+    }
+
+    /**
      * Bestandsaufnahme fuer den Abbruch-Fall. Ohne die Feldnamen aus der
      * betroffenen Umgebung ist nicht entscheidbar, ob das Feld nur umbenannt
      * wurde oder ganz fehlt (Issue #49) -- die Ausgabe ist bewusst so knapp,
@@ -468,6 +497,7 @@
 
             // Neutralisierung erst unmittelbar vor dem Klick, damit ein spaeter
             // React-Re-Render das name-Attribut nicht wiederherstellt.
+            logAdIdResolution(adIdInput);
             adIdInput.removeAttribute('name');
             adIdInput.value = '';
             logger.log('adId Input: name-Attribut entfernt und Wert geleert');
@@ -726,6 +756,7 @@
 
             // Neutralisierung ist Pflicht: nur mit erfolgreich aufgeloestem Input
             // wird der Submit als Neuanlage (statt Bearbeiten) interpretiert.
+            logAdIdResolution(adIdInput);
             adIdInput.removeAttribute('name');
             adIdInput.value = '';
             logger.log('adId Input: name-Attribut entfernt und Wert geleert');
@@ -931,7 +962,7 @@
         typeof process !== 'undefined' && process.versions && process.versions.node) {
         module.exports = {
             CONFIG, getExponentialBackoffWait, readFormFields, collectImageUrls,
-            findAdIdInput, describeAdIdLookup, getUrlAdId
+            findAdIdInput, describeAdIdLookup, describeAdIdResolution, getUrlAdId
         };
         return; // im Test-Kontext keine Initialisierung/Timer
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kleinanzeigen-anzeigen-duplizieren",
-  "version": "3.7.1",
+  "version": "3.7.2",
   "helperVersion": "1.5.0",
   "description": "eBay Kleinanzeigen - Anzeige duplizieren / neu einstellen. Einfaches Duplizieren und Smart Neu-Einstellen von Anzeigen mit automatischer Bilderhaltung",
   "main": "kleinanzeigen-duplizieren.user.js",

--- a/tests/worker.adid.test.js
+++ b/tests/worker.adid.test.js
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import worker from '../kleinanzeigen-duplizieren.user.js';
 
-const { findAdIdInput, describeAdIdLookup, getUrlAdId } = worker;
+const { findAdIdInput, describeAdIdLookup, describeAdIdResolution, getUrlAdId } = worker;
 
 const AD_ID = '3485590892';
 
@@ -84,6 +84,26 @@ describe('findAdIdInput - Fallback ueber den Feldwert (Issue #49)', () => {
     it('liefert null ohne adId in der URL', () => {
         document.body.innerHTML = `<form><input type="hidden" name="unbekannt" value="${AD_ID}"></form>`;
         expect(findAdIdInput(document, null)).toBeNull();
+    });
+});
+
+describe('describeAdIdResolution', () => {
+    it('meldet den bekannten Selektor als Weg', () => {
+        document.body.innerHTML = `<form><input type="hidden" name="adId" value="${AD_ID}"></form>`;
+        const info = describeAdIdResolution(findAdIdInput(document, AD_ID));
+
+        expect(info.weg).toBe('bekannter Selektor');
+        expect(info.feldName).toBe('adId');
+        expect(info.selektorVeraltet).toBe(false);
+    });
+
+    it('meldet den Fallback samt neuem Feldnamen - das Signal fuer eine Umbenennung', () => {
+        document.body.innerHTML = `<form><input type="hidden" name="neuer-name" value="${AD_ID}"></form>`;
+        const info = describeAdIdResolution(findAdIdInput(document, AD_ID));
+
+        expect(info.weg).toBe('Fallback ueber Feldwert');
+        expect(info.feldName).toBe('neuer-name');
+        expect(info.selektorVeraltet).toBe(true);
     });
 });
 


### PR DESCRIPTION
Nachtrag zu Issue #49 (Referenz, kein Auto-Close).

## Warum

Seit v3.7.1 kann das Ad-ID-Feld auf zwei Wegen gefunden werden: über die bekannten Selektoren oder über den Fallback (Hidden-Feld, dessen Wert der `adId` aus der URL entspricht). Beide schrieben bisher dieselbe Log-Zeile.

Damit bleibt der interessante Fall unsichtbar: Greift **nur noch der Fallback**, hat Kleinanzeigen das Feld umbenannt. Das Script funktioniert dann zwar weiter — aber niemand erfährt es, bis auch der Fallback bricht. Genau dieses stille Weiterlaufen hat die Diagnose von #49 gekostet.

## Änderung

Vor der Neutralisierung wird der Auflösungsweg protokolliert:

```
[KA-Script] adId-Feld aufgeloest { weg: "bekannter Selektor", feldName: "adId", selektorVeraltet: false }
```

und im Umbenennungsfall zusätzlich als Warnung:

```
[KA-Script] Bekannte adId-Selektoren greifen nicht mehr, Feld heisst jetzt "…" - bitte im Repository melden
```

Die Bestandsaufnahme läuft bewusst **vor** `removeAttribute('name')` — das Entfernen des Attributs würde das Selektor-Matching verfälschen.

Greift in beiden Pfaden (Duplizieren und Smart-Republish). Keine Verhaltensänderung, reines Logging.

## Verifikation

2 neue Unit-Tests (bekannter Selektor vs. Fallback samt neuem Feldnamen), Suite gesamt **46 grün**, `npm run validate` sauber.

Manuell auf der echten Seite verifiziert wurde die zugrundeliegende Auflösung bereits in #50; hier kommt nur die Protokollierung dazu.

## Version

3.7.1 → **3.7.2** (Patch, Helper unverändert bei 1.5.0), Changelog ergänzt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)