### PR TITLE
feat(helper): Auswahl aller Anzeigen mit Schnellwahl und Farbcodierung (v3.8.0 / Helper 1.7.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Dependencies
-node_modules/
+node_modules
 
 # Environment
 .env

--- a/README.md
+++ b/README.md
@@ -48,6 +48,13 @@ Beide Scripts erhalten automatisch Updates über Tampermonkey.
 2. Neben jedem "Bearbeiten"-Link erscheint der Button "Smart neu einstellen"
 3. Ein Klick öffnet die Bearbeiten-Seite und führt die Aktion automatisch aus
 
+### Batch-Modus (Helper ab v1.3.0)
+1. Öffne "Meine Anzeigen" auf kleinanzeigen.de
+2. Über der Anzeigenliste erscheint der Batch-Button
+3. Das Bestätigungs-Overlay listet alle Anzeigen auf, die älter als 7 Tage sind — **alle vorausgewählt**
+4. Ab Helper v1.6.0: Einzelne Anzeigen lassen sich abwählen (Checkbox), z.B. Daueranzeigen wie Dienstleistungen. "Alle" / "Keine" setzen die komplette Auswahl. Zusammenfassung und geschätzte Laufzeit aktualisieren sich mit
+5. **Start** verarbeitet nur die angehakten Anzeigen nacheinander, mit 3 ± 1 Minuten Pause. Vor jeder Löschung wird ein Recovery-Snapshot in IndexedDB abgelegt
+
 ### Banner & Popup-Blocker (ab v3.4.0)
 Das Script blendet automatisch aus:
 - **Kostenpflichtige Feature-Optionen** (Highlight, Galerie, Bumpup) auf der Bearbeiten-Seite
@@ -96,6 +103,13 @@ Hauptscript verwendet `@grant none`. Helper-Script verwendet ab v1.3.0 `@grant G
 - Das Tab-übergreifende Protokoll zwischen Haupt- und Helper-Script (localStorage-Result-Keys, Fehlercodes, IndexedDB-Snapshots) wird durch die Tests in `tests/helper.protocol.test.js` abgesichert; Änderungen daran müssen in beiden Scripts synchron erfolgen.
 
 ## Changelog
+
+### Helper 1.6.0 (Juli 2026)
+
+- **Neu**: Auswahl im Batch-Bestätigungs-Overlay. Jeder Treffer hat eine Checkbox (standardmäßig angehakt), dazu "Alle"/"Keine". Gestartet wird nur mit den ausgewählten Anzeigen — Daueranzeigen lassen sich so vom Batch ausnehmen, ohne den Schwellwert zu ändern.
+- **Neu**: Zusammenfassung und Laufzeitschätzung aktualisieren sich live ("3 von 8 ausgewählt"); der Start-Button ist gesperrt, solange nichts ausgewählt ist.
+- **Fix**: Die Laufzeitschätzung zählt die Pausen *zwischen* den Anzeigen statt einer Pause pro Anzeige — nach der letzten Anzeige wird nicht mehr gewartet (8 Anzeigen: 21 statt 24 Minuten).
+- **Tests**: `estimateRuntimeMinutes` als reine Funktion herausgezogen und getestet; neue jsdom-Suite `helper.confirm.dom.test.js` prüft das Overlay gegen den echten Produktivcode (Vorauswahl, Abwählen, Alle/Keine, gesperrter Start).
 
 ### Version 3.6.0 / Helper 1.4.0 (Juli 2026)
 

--- a/README.md
+++ b/README.md
@@ -104,14 +104,18 @@ Hauptscript verwendet `@grant none`. Helper-Script verwendet ab v1.3.0 `@grant G
 
 ## Changelog
 
-### Version 3.8.0 / Helper 1.6.0 (August 2026)
+### Version 3.8.0 / Helper 1.7.0 (August 2026)
 
-- **Neu**: Auswahl im Batch-Bestätigungs-Overlay. Jeder Treffer hat eine Checkbox (standardmäßig angehakt), dazu "Alle"/"Keine". Gestartet wird nur mit den ausgewählten Anzeigen — Daueranzeigen lassen sich so vom Batch ausnehmen, ohne den Schwellwert zu ändern. Die Trefferliste selbst ändert sich nicht: abwählen geht, hinzufügen nicht.
-- **Neu**: Zusammenfassung und Laufzeitschätzung aktualisieren sich live ("3 von 8 ausgewählt"); der Start-Button ist gesperrt, solange nichts ausgewählt ist.
-- **Fix**: Die Laufzeitschätzung zählt die Pausen *zwischen* den Anzeigen statt einer Pause pro Anzeige — nach der letzten Anzeige wird nicht mehr gewartet (8 Anzeigen: 21 statt 24 Minuten).
-- **Tests**: `estimateRuntimeMinutes` als reine Funktion herausgezogen und getestet; neue jsdom-Suite `helper.confirm.dom.test.js` prüft das Overlay gegen den echten Produktivcode (Vorauswahl, Abwählen, Alle/Keine, gesperrter Start).
+Das Batch-Overlay ist von "alles Alte, ein Klick" auf eine bewusste Auswahl umgestellt.
 
-  Beigetragen von @karlvonbonin (PR #48).
+- **Neu**: Jede Anzeige bekommt eine Checkbox. Gestartet wird ausschließlich, was angehakt ist. Grundlage beigetragen von @karlvonbonin (PR #48).
+- **Neu**: Die Liste zeigt **alle** Anzeigen, nicht mehr nur die älter als 7 Tage. Beim Öffnen ist **nichts** vorangehakt — ein versehentlicher Start kann damit nichts löschen. Der Button heißt entsprechend "Anzeigen auswählen & neu einstellen".
+- **Neu**: Schnellwahl unter der Liste: "Alle", "Keine", "älter als 7 Tage", "älter als 14 Tage". Jede Schnellwahl *ersetzt* die bestehende Auswahl.
+- **Neu**: Farbcodierung nach Alter — dunkelgrün ab 14 Tagen, grün 7–13 Tage, gelb 5–6 Tage, rot bis 4 Tage. Das Alter steht zusätzlich als Text neben jedem Eintrag, hängt also nicht allein an der Farbe.
+- **Neu**: Zusammenfassung und Laufzeitschätzung laufen mit ("3 von 8 ausgewählt"); der Start-Button bleibt gesperrt, solange nichts ausgewählt ist.
+- **Fix**: Die Laufzeitschätzung zählt die Pausen *zwischen* den Anzeigen statt einer Pause pro Anzeige — nach der letzten Anzeige wird nicht mehr gewartet (8 Anzeigen: 21 statt 24 Minuten). (@karlvonbonin, PR #48)
+- **Hinweis**: Die Kartenliste nennt nur das Enddatum, kein Erstelldatum. Das Alter wird deshalb aus der Restlaufzeit abgeleitet (60 Tage Regellaufzeit) — bei verlängerten Anzeigen ist es ungenau. Die Legende weist darauf hin.
+- **Tests**: `estimateRuntimeMinutes`, `ageFromDaysLeft` und `ageBand` als reine Funktionen getestet; die jsdom-Suite `helper.confirm.dom.test.js` prüft das Overlay gegen den echten Produktivcode (leere Vorauswahl, Schnellwahl, Farbbänder, gesperrter Start).
 
 ### Version 3.7.1 (August 2026)
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Hauptscript verwendet `@grant none`. Helper-Script verwendet ab v1.3.0 `@grant G
 
 ## Changelog
 
-### Helper 1.6.0 (August 2026)
+### Version 3.8.0 / Helper 1.6.0 (August 2026)
 
 - **Neu**: Auswahl im Batch-Bestätigungs-Overlay. Jeder Treffer hat eine Checkbox (standardmäßig angehakt), dazu "Alle"/"Keine". Gestartet wird nur mit den ausgewählten Anzeigen — Daueranzeigen lassen sich so vom Batch ausnehmen, ohne den Schwellwert zu ändern. Die Trefferliste selbst ändert sich nicht: abwählen geht, hinzufügen nicht.
 - **Neu**: Zusammenfassung und Laufzeitschätzung aktualisieren sich live ("3 von 8 ausgewählt"); der Start-Button ist gesperrt, solange nichts ausgewählt ist.

--- a/helper.user.js
+++ b/helper.user.js
@@ -5,7 +5,7 @@
 // @icon          https://www.kleinanzeigen.de/favicon.ico
 // @copyright     2026
 // @license       MIT
-// @version       1.6.0
+// @version       1.7.0
 // @author        panzli (Original), OldRon1977 (Anpassungen)
 // @match         https://www.kleinanzeigen.de/m-meine-anzeigen.html*
 // @homepage      https://github.com/OldRon1977/Kleinanzeigen-Anzeigen-duplizieren
@@ -23,6 +23,22 @@
     // als "aelter als 7 Tage", wenn das Enddatum hoechstens (60 - 7) = 53 Tage
     // in der Zukunft liegt.
     const MIN_DAYS_TO_END = 53;
+
+    // Regellaufzeit einer Kleinanzeige. Die Kartenliste nennt nur das ENDdatum,
+    // kein Erstelldatum -- das Alter ist daher immer abgeleitet:
+    // Alter = AD_RUNTIME_DAYS - Restlaufzeit. Dieselbe Annahme steckt seit jeher
+    // in MIN_DAYS_TO_END (60 - 7 = 53). Bei abweichender Laufzeit (verlaengert,
+    // gewerblich) ist das Alter entsprechend ungenau; die UI weist darauf hin.
+    const AD_RUNTIME_DAYS = 60;
+
+    // Farbcodierung nach Alter. Untergrenze inklusive, nach oben offen bis zum
+    // naechsten Band: rot 0-4, gelb 5-6, gruen 7-13, dunkelgruen ab 14 Tagen.
+    const AGE_BANDS = [
+        { key: 'sehr-alt', minAge: 14, color: '#1b5e20', label: 'ab 14 Tagen' },
+        { key: 'alt', minAge: 7, color: '#43a047', label: '7-13 Tage' },
+        { key: 'mittel', minAge: 5, color: '#f9a825', label: '5-6 Tage' },
+        { key: 'frisch', minAge: 0, color: '#e53935', label: 'bis 4 Tage' }
+    ];
 
     // Jitter-Delay zwischen zwei Smart-Republish-Vorgaengen: 3 +- 1 Minuten.
     const DELAY_BASE_MS = 3 * 60 * 1000;
@@ -422,8 +438,8 @@
         const btn = document.createElement('button');
         btn.id = TRIGGER_BTN_ID;
         btn.type = 'button';
-        btn.textContent = '\u23F0 Alle alten neu einstellen';
-        btn.title = 'Stellt alle Anzeigen älter als 7 Tage nacheinander mit Zeitabstand neu ein';
+        btn.textContent = '\u2611 Anzeigen auswählen & neu einstellen';
+        btn.title = 'Öffnet die Auswahl aller Anzeigen; die ausgewählten werden nacheinander mit Zeitabstand neu eingestellt';
         btn.style.cssText = [
             'margin: 0 0 12px 0',
             'padding: 8px 16px',
@@ -476,10 +492,17 @@
                 return;
             }
 
+            // Es werden ALLE Anzeigen mit lesbarem Datum gelistet, nicht mehr nur
+            // die aelteren. Was tatsaechlich laeuft, entscheidet die Auswahl im
+            // Overlay -- dort ist beim Oeffnen nichts angehakt.
             const days = daysUntil(endDate);
-            if (days <= MIN_DAYS_TO_END) {
-                matches.push({ adId: adId, title: title, endText: endText, daysLeft: days });
-            }
+            matches.push({
+                adId: adId,
+                title: title,
+                endText: endText,
+                daysLeft: days,
+                ageDays: ageFromDaysLeft(days)
+            });
         });
 
         return { matches: matches, skipped: skipped };
@@ -565,6 +588,18 @@
         parent.appendChild(sec);
     }
 
+    // Abgeleitetes Alter in Tagen (siehe AD_RUNTIME_DAYS). Nie negativ: eine
+    // frisch verlaengerte Anzeige kann mehr Restlaufzeit haben als die
+    // Regellaufzeit, das waere sonst ein negatives Alter.
+    function ageFromDaysLeft(daysLeft) {
+        return Math.max(0, AD_RUNTIME_DAYS - daysLeft);
+    }
+
+    function ageBand(ageDays) {
+        return AGE_BANDS.find(function (b) { return ageDays >= b.minAge; }) ||
+            AGE_BANDS[AGE_BANDS.length - 1];
+    }
+
     // Geschaetzte Batch-Laufzeit in Minuten. Zwischen zwei Anzeigen liegt eine
     // Pause von DELAY_BASE_MS; nach der letzten Anzeige wird nicht mehr gewartet.
     function estimateRuntimeMinutes(count) {
@@ -593,7 +628,7 @@
         const summary = document.createElement('div');
         summary.style.cssText = 'padding:10px 14px;border-bottom:1px solid #eee;';
         if (matches.length === 0) {
-            summary.textContent = 'Keine Anzeigen älter als 7 Tage gefunden.';
+            summary.textContent = 'Keine Anzeigen mit lesbarem Enddatum gefunden.';
             overlay.appendChild(summary);
             // Trotzdem Recovery-Section anzeigen, falls Snapshots da sind
             try {
@@ -602,11 +637,12 @@
             } catch (e) { warn('Recovery-Listing fehlgeschlagen', e); }
             return;
         }
-        // Auswahl: standardmaessig sind alle Treffer angehakt. Einzelne Anzeigen
-        // lassen sich abwaehlen (z.B. Daueranzeigen, die nicht erneuert werden
-        // sollen); gestartet wird nur mit den angehakten Eintraegen.
-        const selected = new Set(matches.map(function (m) { return m.adId; }));
-        const checkboxes = [];
+        // Auswahl startet LEER. Gelistet sind alle Anzeigen, auch frische --
+        // deshalb waere "alles vorangehakt" ein scharfes Messer: ein Klick auf
+        // Start wuerde jede Anzeige loeschen und neu anlegen. Die Schnellwahl
+        // unter der Liste nimmt die Klickarbeit fuer die ueblichen Faelle ab.
+        const selected = new Set();
+        const entries = [];
 
         const line1 = document.createElement('div');
         summary.appendChild(line1);
@@ -626,14 +662,24 @@
 
             const cb = document.createElement('input');
             cb.type = 'checkbox';
-            cb.checked = true;
+            cb.checked = false;
             cb.style.cssText = 'margin-top:2px;flex:none;cursor:pointer;';
             cb.onchange = function () {
                 if (cb.checked) selected.add(m.adId);
                 else selected.delete(m.adId);
                 updateSummary();
             };
-            checkboxes.push(cb);
+            entries.push({ match: m, cb: cb });
+
+            // Farbpunkt nach Alter -- traegt die Information doppelt (Farbe und
+            // Text daneben), damit sie nicht allein an der Farbe haengt.
+            const age = typeof m.ageDays === 'number' ? m.ageDays : ageFromDaysLeft(m.daysLeft);
+            const band = ageBand(age);
+            const dot = document.createElement('span');
+            dot.className = 'ka-age-dot';
+            dot.dataset.band = band.key;
+            dot.title = 'Alter ' + band.label;
+            dot.style.cssText = 'width:10px;height:10px;border-radius:50%;flex:none;margin-top:5px;background:' + band.color + ';';
 
             const texts = document.createElement('div');
             const t = document.createElement('div');
@@ -641,33 +687,71 @@
             t.textContent = m.title;
             const meta = document.createElement('div');
             meta.style.cssText = 'color:#666;font-size:12px;';
-            meta.textContent = 'ID ' + m.adId + ' \u00B7 endet ' + m.endText + ' (' + m.daysLeft + ' Tage)';
+            meta.textContent = 'ID ' + m.adId + ' \u00B7 ' + age + ' Tage alt \u00B7 endet ' + m.endText +
+                ' (' + m.daysLeft + ' Tage)';
             texts.appendChild(t);
             texts.appendChild(meta);
 
             label.appendChild(cb);
+            label.appendChild(dot);
             label.appendChild(texts);
             li.appendChild(label);
             list.appendChild(li);
         });
         overlay.appendChild(list);
 
+        // Schnellwahl: setzt die Auswahl auf alles, was das Praedikat erfuellt.
+        // Checkboxen werden programmatisch gesetzt (feuert kein onchange),
+        // deshalb wird `selected` hier mitgefuehrt.
+        function applySelection(predicate) {
+            selected.clear();
+            entries.forEach(function (e) {
+                const age = typeof e.match.ageDays === 'number'
+                    ? e.match.ageDays
+                    : ageFromDaysLeft(e.match.daysLeft);
+                const hit = predicate(e.match, age);
+                e.cb.checked = hit;
+                if (hit) selected.add(e.match.adId);
+            });
+            updateSummary();
+        }
+
         const bulk = document.createElement('div');
-        bulk.style.cssText = 'padding:0 14px 8px;display:flex;gap:12px;font-size:12px;';
-        [['Alle', true], ['Keine', false]].forEach(function (pair) {
+        bulk.style.cssText = 'padding:0 14px 8px;display:flex;gap:12px;font-size:12px;flex-wrap:wrap;';
+        [
+            ['Alle', function () { return true; }],
+            ['Keine', function () { return false; }],
+            ['älter als 7 Tage', function (m, age) { return age >= 7; }],
+            ['älter als 14 Tage', function (m, age) { return age >= 14; }]
+        ].forEach(function (pair) {
             const b = document.createElement('button');
             b.type = 'button';
             b.textContent = pair[0];
             b.style.cssText = 'background:none;border:none;padding:0;color:#007bff;cursor:pointer;font-size:12px;text-decoration:underline;';
-            b.onclick = function () {
-                checkboxes.forEach(function (c) { c.checked = pair[1]; });
-                selected.clear();
-                if (pair[1]) matches.forEach(function (m) { selected.add(m.adId); });
-                updateSummary();
-            };
+            b.onclick = function () { applySelection(pair[1]); };
             bulk.appendChild(b);
         });
         overlay.appendChild(bulk);
+
+        // Legende: erklaert die Farbpunkte und macht transparent, dass das Alter
+        // aus der Restlaufzeit abgeleitet ist (die Karte nennt kein Erstelldatum).
+        const legend = document.createElement('div');
+        legend.style.cssText = 'padding:0 14px 8px;display:flex;gap:10px;flex-wrap:wrap;font-size:11px;color:#666;';
+        AGE_BANDS.forEach(function (band) {
+            const item = document.createElement('span');
+            item.style.cssText = 'display:flex;gap:4px;align-items:center;';
+            const dot = document.createElement('span');
+            dot.style.cssText = 'width:8px;height:8px;border-radius:50%;background:' + band.color + ';';
+            item.appendChild(dot);
+            item.appendChild(document.createTextNode(band.label));
+            legend.appendChild(item);
+        });
+        const hint = document.createElement('div');
+        hint.style.cssText = 'padding:0 14px 8px;font-size:11px;color:#999;';
+        hint.textContent = 'Alter geschätzt aus der Restlaufzeit (' + AD_RUNTIME_DAYS +
+            ' Tage Regellaufzeit) – bei verlängerten Anzeigen ungenau.';
+        overlay.appendChild(legend);
+        overlay.appendChild(hint);
 
         if (skipped.length > 0) {
             const sk = document.createElement('div');
@@ -705,8 +789,8 @@
             line1.appendChild(strong);
             line1.appendChild(document.createTextNode(' von ' + matches.length + ' Anzeige(n) ausgewählt.'));
             line2.textContent = count > 0
-                ? 'Geschätzte Laufzeit: ca. ' + estimateRuntimeMinutes(count) + ' Minuten (3 ± 1 min Pause pro Anzeige).'
-                : 'Keine Anzeige ausgewählt.';
+                ? 'Geschätzte Laufzeit: ca. ' + estimateRuntimeMinutes(count) + ' Minuten (3 ± 1 min Pause zwischen zwei Anzeigen).'
+                : 'Nichts ausgewählt – Schnellwahl unter der Liste nutzen.';
             start.disabled = (count === 0);
             start.style.opacity = count === 0 ? '0.5' : '1';
             start.style.cursor = count === 0 ? 'not-allowed' : 'pointer';
@@ -1053,8 +1137,12 @@
         typeof process !== 'undefined' && process.versions && process.versions.node) {
         module.exports = {
             MIN_DAYS_TO_END,
+            AD_RUNTIME_DAYS,
+            AGE_BANDS,
             parseEndDate,
             daysUntil,
+            ageFromDaysLeft,
+            ageBand,
             estimateRuntimeMinutes,
             renderConfirm,
             jitterDelay,

--- a/helper.user.js
+++ b/helper.user.js
@@ -7,6 +7,7 @@
 // @license       MIT
 // @version       1.7.0
 // @author        panzli (Original), OldRon1977 (Anpassungen)
+// @credits       karlvonbonin - Idee und Grundlage der Auswahl im Batch-Overlay (PR #48)
 // @match         https://www.kleinanzeigen.de/m-meine-anzeigen.html*
 // @homepage      https://github.com/OldRon1977/Kleinanzeigen-Anzeigen-duplizieren
 // @updateURL     https://github.com/OldRon1977/Kleinanzeigen-Anzeigen-duplizieren/raw/main/helper.user.js

--- a/helper.user.js
+++ b/helper.user.js
@@ -5,7 +5,7 @@
 // @icon          https://www.kleinanzeigen.de/favicon.ico
 // @copyright     2026
 // @license       MIT
-// @version       1.5.0
+// @version       1.6.0
 // @author        panzli (Original), OldRon1977 (Anpassungen)
 // @match         https://www.kleinanzeigen.de/m-meine-anzeigen.html*
 // @homepage      https://github.com/OldRon1977/Kleinanzeigen-Anzeigen-duplizieren
@@ -565,10 +565,15 @@
         parent.appendChild(sec);
     }
 
+    // Geschaetzte Batch-Laufzeit in Minuten. Zwischen zwei Anzeigen liegt eine
+    // Pause von DELAY_BASE_MS; nach der letzten Anzeige wird nicht mehr gewartet.
+    function estimateRuntimeMinutes(count) {
+        if (count <= 0) return 0;
+        return Math.round((count - 1) * DELAY_BASE_MS / 60000);
+    }
+
     async function renderConfirm(matches, skipped, onStart) {
         const overlay = ensureOverlay();
-        const totalMs = matches.length * (DELAY_BASE_MS);
-        const minutes = Math.round(totalMs / 60000);
 
         overlay.innerHTML = '';
 
@@ -597,34 +602,72 @@
             } catch (e) { warn('Recovery-Listing fehlgeschlagen', e); }
             return;
         }
+        // Auswahl: standardmaessig sind alle Treffer angehakt. Einzelne Anzeigen
+        // lassen sich abwaehlen (z.B. Daueranzeigen, die nicht erneuert werden
+        // sollen); gestartet wird nur mit den angehakten Eintraegen.
+        const selected = new Set(matches.map(function (m) { return m.adId; }));
+        const checkboxes = [];
+
         const line1 = document.createElement('div');
-        const strong = document.createElement('strong');
-        strong.textContent = matches.length;
-        line1.appendChild(strong);
-        line1.appendChild(document.createTextNode(' Anzeige(n) werden bearbeitet.'));
         summary.appendChild(line1);
         const line2 = document.createElement('div');
         line2.style.cssText = 'color:#666;margin-top:4px;';
-        line2.textContent = 'Geschätzte Laufzeit: ca. ' + minutes + ' Minuten (3 ± 1 min Pause pro Anzeige).';
         summary.appendChild(line2);
         overlay.appendChild(summary);
 
-        const list = document.createElement('ol');
-        list.style.cssText = 'margin:0;padding:8px 14px 8px 32px;max-height:240px;overflow-y:auto;';
+        const list = document.createElement('ul');
+        list.style.cssText = 'margin:0;padding:8px 14px;max-height:240px;overflow-y:auto;list-style:none;';
         matches.forEach(function (m) {
             const li = document.createElement('li');
             li.style.cssText = 'margin:4px 0;line-height:1.3;';
+
+            const label = document.createElement('label');
+            label.style.cssText = 'display:flex;gap:8px;align-items:flex-start;cursor:pointer;';
+
+            const cb = document.createElement('input');
+            cb.type = 'checkbox';
+            cb.checked = true;
+            cb.style.cssText = 'margin-top:2px;flex:none;cursor:pointer;';
+            cb.onchange = function () {
+                if (cb.checked) selected.add(m.adId);
+                else selected.delete(m.adId);
+                updateSummary();
+            };
+            checkboxes.push(cb);
+
+            const texts = document.createElement('div');
             const t = document.createElement('div');
             t.style.cssText = 'font-weight:500;';
             t.textContent = m.title;
             const meta = document.createElement('div');
             meta.style.cssText = 'color:#666;font-size:12px;';
             meta.textContent = 'ID ' + m.adId + ' \u00B7 endet ' + m.endText + ' (' + m.daysLeft + ' Tage)';
-            li.appendChild(t);
-            li.appendChild(meta);
+            texts.appendChild(t);
+            texts.appendChild(meta);
+
+            label.appendChild(cb);
+            label.appendChild(texts);
+            li.appendChild(label);
             list.appendChild(li);
         });
         overlay.appendChild(list);
+
+        const bulk = document.createElement('div');
+        bulk.style.cssText = 'padding:0 14px 8px;display:flex;gap:12px;font-size:12px;';
+        [['Alle', true], ['Keine', false]].forEach(function (pair) {
+            const b = document.createElement('button');
+            b.type = 'button';
+            b.textContent = pair[0];
+            b.style.cssText = 'background:none;border:none;padding:0;color:#007bff;cursor:pointer;font-size:12px;text-decoration:underline;';
+            b.onclick = function () {
+                checkboxes.forEach(function (c) { c.checked = pair[1]; });
+                selected.clear();
+                if (pair[1]) matches.forEach(function (m) { selected.add(m.adId); });
+                updateSummary();
+            };
+            bulk.appendChild(b);
+        });
+        overlay.appendChild(bulk);
 
         if (skipped.length > 0) {
             const sk = document.createElement('div');
@@ -644,10 +687,31 @@
         const cancel = makeButton('Abbrechen', false);
         cancel.onclick = closeOverlay;
         const start = makeButton('Start', true);
-        start.onclick = function () { onStart(matches); };
+        start.onclick = function () {
+            const chosen = matches.filter(function (m) { return selected.has(m.adId); });
+            if (!chosen.length) return;
+            onStart(chosen);
+        };
         actions.appendChild(cancel);
         actions.appendChild(start);
         overlay.appendChild(actions);
+
+        // Haelt Zusammenfassung und Start-Button im Einklang mit der Auswahl.
+        function updateSummary() {
+            const count = selected.size;
+            line1.textContent = '';
+            const strong = document.createElement('strong');
+            strong.textContent = count;
+            line1.appendChild(strong);
+            line1.appendChild(document.createTextNode(' von ' + matches.length + ' Anzeige(n) ausgewählt.'));
+            line2.textContent = count > 0
+                ? 'Geschätzte Laufzeit: ca. ' + estimateRuntimeMinutes(count) + ' Minuten (3 ± 1 min Pause pro Anzeige).'
+                : 'Keine Anzeige ausgewählt.';
+            start.disabled = (count === 0);
+            start.style.opacity = count === 0 ? '0.5' : '1';
+            start.style.cursor = count === 0 ? 'not-allowed' : 'pointer';
+        }
+        updateSummary();
     }
 
     function renderProgress(state, onStop) {
@@ -991,6 +1055,8 @@
             MIN_DAYS_TO_END,
             parseEndDate,
             daysUntil,
+            estimateRuntimeMinutes,
+            renderConfirm,
             jitterDelay,
             sanitize,
             crc32,

--- a/kleinanzeigen-duplizieren.user.js
+++ b/kleinanzeigen-duplizieren.user.js
@@ -5,7 +5,7 @@
 // @icon          https://www.kleinanzeigen.de/favicon.ico
 // @copyright     2026
 // @license       MIT
-// @version       3.7.1
+// @version       3.8.0
 // @author        OldRon1977 (Improvements), J05HI (Original)
 // @credits       Basierend auf dem Original-Script von J05HI (https://gist.github.com/J05HI/9f3fc7a496e8baeff5a56e0c1a710bb5)
 // @match         https://www.kleinanzeigen.de/p-anzeige-bearbeiten.html*
@@ -35,7 +35,7 @@
 (function () {
     'use strict';
 
-    const SCRIPT_VERSION = '3.7.1'; // wird von scripts/build.js synchron zu package.json gehalten
+    const SCRIPT_VERSION = '3.8.0'; // wird von scripts/build.js synchron zu package.json gehalten
 
     // === KONSTANTEN ===
     const CONFIG = {

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/home/tiger/Dokumente/GitHub/Kleinanzeigen-Anzeigen-duplizieren/node_modules

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kleinanzeigen-anzeigen-duplizieren",
-  "version": "3.7.1",
+  "version": "3.8.0",
   "helperVersion": "1.6.0",
   "description": "eBay Kleinanzeigen - Anzeige duplizieren / neu einstellen. Einfaches Duplizieren und Smart Neu-Einstellen von Anzeigen mit automatischer Bilderhaltung",
   "main": "kleinanzeigen-duplizieren.user.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kleinanzeigen-anzeigen-duplizieren",
   "version": "3.7.0",
-  "helperVersion": "1.5.0",
+  "helperVersion": "1.6.0",
   "description": "eBay Kleinanzeigen - Anzeige duplizieren / neu einstellen. Einfaches Duplizieren und Smart Neu-Einstellen von Anzeigen mit automatischer Bilderhaltung",
   "main": "kleinanzeigen-duplizieren.user.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kleinanzeigen-anzeigen-duplizieren",
   "version": "3.8.0",
-  "helperVersion": "1.6.0",
+  "helperVersion": "1.7.0",
   "description": "eBay Kleinanzeigen - Anzeige duplizieren / neu einstellen. Einfaches Duplizieren und Smart Neu-Einstellen von Anzeigen mit automatischer Bilderhaltung",
   "main": "kleinanzeigen-duplizieren.user.js",
   "scripts": {

--- a/tests/helper.confirm.dom.test.js
+++ b/tests/helper.confirm.dom.test.js
@@ -3,10 +3,14 @@ import helper from '../helper.user.js';
 
 const { renderConfirm } = helper;
 
+// daysLeft -> abgeleitetes Alter (60 - daysLeft):
+//   40 -> 20 Tage (dunkelgruen), 50 -> 10 Tage (gruen),
+//   55 ->  5 Tage (gelb),        58 ->  2 Tage (rot)
 const MATCHES = [
-    { adId: '1001', title: 'Fahrrad', endText: '12.09.2026', daysLeft: 48 },
-    { adId: '1002', title: 'Buerostuhl', endText: '10.09.2026', daysLeft: 46 },
-    { adId: '1003', title: 'Hecke schneiden', endText: '05.09.2026', daysLeft: 41 }
+    { adId: '1001', title: 'Fahrrad', endText: '12.09.2026', daysLeft: 40, ageDays: 20 },
+    { adId: '1002', title: 'Buerostuhl', endText: '22.09.2026', daysLeft: 50, ageDays: 10 },
+    { adId: '1003', title: 'Hecke schneiden', endText: '27.09.2026', daysLeft: 55, ageDays: 5 },
+    { adId: '1004', title: 'Kaffeemaschine', endText: '30.09.2026', daysLeft: 58, ageDays: 2 }
 ];
 
 // renderConfirm ruft listSnapshotMeta() -> indexedDB auf. In jsdom existiert
@@ -25,6 +29,10 @@ function buttonByText(text) {
         .find((b) => b.textContent === text);
 }
 
+function checkedIds() {
+    return MATCHES.filter((m, i) => checkboxes()[i].checked).map((m) => m.adId);
+}
+
 function summaryText() {
     return overlay().textContent;
 }
@@ -33,60 +41,111 @@ beforeEach(() => {
     document.body.innerHTML = '';
 });
 
-describe('renderConfirm – Auswahl', () => {
-    it('hakt alle Treffer standardmaessig an', async () => {
+describe('renderConfirm – Auswahl startet leer', () => {
+    it('hakt nichts vor und sperrt Start', async () => {
         await renderConfirm(MATCHES, [], () => {});
-        const cbs = checkboxes();
-        expect(cbs).toHaveLength(3);
-        expect(cbs.every((c) => c.checked)).toBe(true);
-        expect(summaryText()).toContain('3 von 3');
-    });
 
-    it('startet nur mit den angehakten Anzeigen', async () => {
-        let started = null;
-        await renderConfirm(MATCHES, [], (chosen) => { started = chosen; });
-
-        checkboxes()[2].checked = false;
-        checkboxes()[2].onchange();
-
-        expect(summaryText()).toContain('2 von 3');
-        buttonByText('Start').click();
-
-        expect(started.map((m) => m.adId)).toEqual(['1001', '1002']);
-    });
-
-    it('sperrt Start, wenn nichts ausgewaehlt ist', async () => {
-        let started = null;
-        await renderConfirm(MATCHES, [], (chosen) => { started = chosen; });
-
-        buttonByText('Keine').click();
-
+        expect(checkboxes()).toHaveLength(4);
         expect(checkboxes().every((c) => !c.checked)).toBe(true);
+        expect(summaryText()).toContain('0 von 4');
         expect(buttonByText('Start').disabled).toBe(true);
+    });
+
+    it('startet nicht, solange nichts ausgewaehlt ist', async () => {
+        let started = null;
+        await renderConfirm(MATCHES, [], (chosen) => { started = chosen; });
 
         buttonByText('Start').click();
         expect(started).toBeNull();
     });
 
-    it('stellt mit "Alle" die vollstaendige Auswahl wieder her', async () => {
+    it('startet mit genau den angehakten Anzeigen', async () => {
         let started = null;
         await renderConfirm(MATCHES, [], (chosen) => { started = chosen; });
 
-        buttonByText('Keine').click();
-        buttonByText('Alle').click();
+        checkboxes()[1].checked = true;
+        checkboxes()[1].onchange();
 
-        expect(checkboxes().every((c) => c.checked)).toBe(true);
-        expect(summaryText()).toContain('3 von 3');
+        expect(summaryText()).toContain('1 von 4');
+        expect(buttonByText('Start').disabled).toBe(false);
 
         buttonByText('Start').click();
-        expect(started).toHaveLength(3);
+        expect(started.map((m) => m.adId)).toEqual(['1002']);
+    });
+});
+
+describe('renderConfirm – Schnellwahl', () => {
+    it('"Alle" waehlt alles, "Keine" raeumt wieder ab', async () => {
+        await renderConfirm(MATCHES, [], () => {});
+
+        buttonByText('Alle').click();
+        expect(checkedIds()).toEqual(['1001', '1002', '1003', '1004']);
+        expect(summaryText()).toContain('4 von 4');
+
+        buttonByText('Keine').click();
+        expect(checkedIds()).toEqual([]);
+        expect(buttonByText('Start').disabled).toBe(true);
     });
 
-    it('zeigt Treffer mit Titel, ID und Enddatum an', async () => {
+    it('"älter als 7 Tage" nimmt nur die ab 7 Tagen', async () => {
+        await renderConfirm(MATCHES, [], () => {});
+
+        buttonByText('älter als 7 Tage').click();
+        expect(checkedIds()).toEqual(['1001', '1002']);
+    });
+
+    it('"älter als 14 Tage" nimmt nur die ab 14 Tagen', async () => {
+        await renderConfirm(MATCHES, [], () => {});
+
+        buttonByText('älter als 14 Tage').click();
+        expect(checkedIds()).toEqual(['1001']);
+    });
+
+    it('ersetzt eine bestehende Auswahl, statt sie zu ergaenzen', async () => {
+        await renderConfirm(MATCHES, [], () => {});
+
+        buttonByText('Alle').click();
+        buttonByText('älter als 14 Tage').click();
+
+        expect(checkedIds()).toEqual(['1001']);
+        expect(summaryText()).toContain('1 von 4');
+    });
+});
+
+describe('renderConfirm – Farbcodierung', () => {
+    it('vergibt das Farbband nach Alter', async () => {
+        await renderConfirm(MATCHES, [], () => {});
+
+        const bands = Array.from(overlay().querySelectorAll('li .ka-age-dot'))
+            .map((d) => d.dataset.band);
+        expect(bands).toEqual(['sehr-alt', 'alt', 'mittel', 'frisch']);
+    });
+
+    it('leitet das Alter aus daysLeft ab, wenn ageDays fehlt', async () => {
+        await renderConfirm([{ adId: '9', title: 'Ohne Alter', endText: '01.10.2026', daysLeft: 46 }], [], () => {});
+
+        const dot = overlay().querySelector('li .ka-age-dot');
+        expect(dot.dataset.band).toBe('sehr-alt');   // 60 - 46 = 14 Tage
+    });
+
+    it('nennt das Alter auch im Text, nicht nur als Farbe', async () => {
+        await renderConfirm(MATCHES, [], () => {});
+        expect(summaryText()).toContain('20 Tage alt');
+        expect(summaryText()).toContain('2 Tage alt');
+    });
+});
+
+describe('renderConfirm – Bestandsanzeige', () => {
+    it('listet alle Anzeigen, nicht nur die alten', async () => {
         await renderConfirm(MATCHES, [], () => {});
         const text = summaryText();
-        expect(text).toContain('Hecke schneiden');
+        expect(text).toContain('Kaffeemaschine');   // 2 Tage alt
+        expect(text).toContain('Fahrrad');          // 20 Tage alt
         expect(text).toContain('ID 1003');
-        expect(text).toContain('05.09.2026');
+    });
+
+    it('meldet Karten ohne Datum getrennt', async () => {
+        await renderConfirm(MATCHES, [{ adId: 'x', title: 'Kaputt', reason: 'kein Datum' }], () => {});
+        expect(summaryText()).toContain('1 Karte(n) ohne Datum übersprungen.');
     });
 });

--- a/tests/helper.confirm.dom.test.js
+++ b/tests/helper.confirm.dom.test.js
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import helper from '../helper.user.js';
+
+const { renderConfirm } = helper;
+
+const MATCHES = [
+    { adId: '1001', title: 'Fahrrad', endText: '12.09.2026', daysLeft: 48 },
+    { adId: '1002', title: 'Buerostuhl', endText: '10.09.2026', daysLeft: 46 },
+    { adId: '1003', title: 'Hecke schneiden', endText: '05.09.2026', daysLeft: 41 }
+];
+
+// renderConfirm ruft listSnapshotMeta() -> indexedDB auf. In jsdom existiert
+// kein indexedDB; der Aufruf ist im Produktivcode in try/catch gekapselt und
+// die Recovery-Section entfaellt dann einfach.
+function overlay() {
+    return document.getElementById('ka-batch-overlay');
+}
+
+function checkboxes() {
+    return Array.from(overlay().querySelectorAll('input[type="checkbox"]'));
+}
+
+function buttonByText(text) {
+    return Array.from(overlay().querySelectorAll('button'))
+        .find((b) => b.textContent === text);
+}
+
+function summaryText() {
+    return overlay().textContent;
+}
+
+beforeEach(() => {
+    document.body.innerHTML = '';
+});
+
+describe('renderConfirm – Auswahl', () => {
+    it('hakt alle Treffer standardmaessig an', async () => {
+        await renderConfirm(MATCHES, [], () => {});
+        const cbs = checkboxes();
+        expect(cbs).toHaveLength(3);
+        expect(cbs.every((c) => c.checked)).toBe(true);
+        expect(summaryText()).toContain('3 von 3');
+    });
+
+    it('startet nur mit den angehakten Anzeigen', async () => {
+        let started = null;
+        await renderConfirm(MATCHES, [], (chosen) => { started = chosen; });
+
+        checkboxes()[2].checked = false;
+        checkboxes()[2].onchange();
+
+        expect(summaryText()).toContain('2 von 3');
+        buttonByText('Start').click();
+
+        expect(started.map((m) => m.adId)).toEqual(['1001', '1002']);
+    });
+
+    it('sperrt Start, wenn nichts ausgewaehlt ist', async () => {
+        let started = null;
+        await renderConfirm(MATCHES, [], (chosen) => { started = chosen; });
+
+        buttonByText('Keine').click();
+
+        expect(checkboxes().every((c) => !c.checked)).toBe(true);
+        expect(buttonByText('Start').disabled).toBe(true);
+
+        buttonByText('Start').click();
+        expect(started).toBeNull();
+    });
+
+    it('stellt mit "Alle" die vollstaendige Auswahl wieder her', async () => {
+        let started = null;
+        await renderConfirm(MATCHES, [], (chosen) => { started = chosen; });
+
+        buttonByText('Keine').click();
+        buttonByText('Alle').click();
+
+        expect(checkboxes().every((c) => c.checked)).toBe(true);
+        expect(summaryText()).toContain('3 von 3');
+
+        buttonByText('Start').click();
+        expect(started).toHaveLength(3);
+    });
+
+    it('zeigt Treffer mit Titel, ID und Enddatum an', async () => {
+        await renderConfirm(MATCHES, [], () => {});
+        const text = summaryText();
+        expect(text).toContain('Hecke schneiden');
+        expect(text).toContain('ID 1003');
+        expect(text).toContain('05.09.2026');
+    });
+});

--- a/tests/helper.logic.test.js
+++ b/tests/helper.logic.test.js
@@ -5,6 +5,9 @@ const {
     MIN_DAYS_TO_END,
     parseEndDate,
     daysUntil,
+    AGE_BANDS,
+    ageFromDaysLeft,
+    ageBand,
     estimateRuntimeMinutes,
     jitterDelay,
     sanitize,
@@ -60,6 +63,38 @@ describe('daysUntil', () => {
 
     it('MIN_DAYS_TO_END ist der dokumentierte Schwellwert 53', () => {
         expect(MIN_DAYS_TO_END).toBe(53);
+    });
+});
+
+describe('ageFromDaysLeft', () => {
+    it('leitet das Alter aus der Restlaufzeit ab (60 Tage Regellaufzeit)', () => {
+        expect(ageFromDaysLeft(60)).toBe(0);
+        expect(ageFromDaysLeft(53)).toBe(7);
+        expect(ageFromDaysLeft(46)).toBe(14);
+    });
+
+    it('wird nie negativ, auch bei verlaengerten Anzeigen', () => {
+        expect(ageFromDaysLeft(75)).toBe(0);
+    });
+});
+
+describe('ageBand', () => {
+    it('trifft die Grenzen der vier Baender', () => {
+        expect(ageBand(0).key).toBe('frisch');     // rot: bis 4 Tage
+        expect(ageBand(4).key).toBe('frisch');
+        expect(ageBand(5).key).toBe('mittel');     // gelb: 5-6 Tage
+        expect(ageBand(6).key).toBe('mittel');
+        expect(ageBand(7).key).toBe('alt');        // gruen: 7-13 Tage
+        expect(ageBand(13).key).toBe('alt');
+        expect(ageBand(14).key).toBe('sehr-alt');  // dunkelgruen: ab 14 Tagen
+        expect(ageBand(365).key).toBe('sehr-alt');
+    });
+
+    it('liefert zu jedem Band eine Farbe und ein Label', () => {
+        AGE_BANDS.forEach((band) => {
+            expect(band.color).toMatch(/^#[0-9a-f]{6}$/i);
+            expect(band.label.length).toBeGreaterThan(0);
+        });
     });
 });
 

--- a/tests/helper.logic.test.js
+++ b/tests/helper.logic.test.js
@@ -5,6 +5,7 @@ const {
     MIN_DAYS_TO_END,
     parseEndDate,
     daysUntil,
+    estimateRuntimeMinutes,
     jitterDelay,
     sanitize,
     crc32,
@@ -59,6 +60,25 @@ describe('daysUntil', () => {
 
     it('MIN_DAYS_TO_END ist der dokumentierte Schwellwert 53', () => {
         expect(MIN_DAYS_TO_END).toBe(53);
+    });
+});
+
+describe('estimateRuntimeMinutes', () => {
+    it('liefert 0 fuer leere Auswahl', () => {
+        expect(estimateRuntimeMinutes(0)).toBe(0);
+    });
+
+    it('liefert 0 fuer eine einzelne Anzeige (keine Pause danach)', () => {
+        expect(estimateRuntimeMinutes(1)).toBe(0);
+    });
+
+    it('rechnet die Pausen ZWISCHEN den Anzeigen', () => {
+        expect(estimateRuntimeMinutes(2)).toBe(3);   // 1 Pause
+        expect(estimateRuntimeMinutes(8)).toBe(21);  // 7 Pausen
+    });
+
+    it('liefert 0 fuer negative Werte', () => {
+        expect(estimateRuntimeMinutes(-3)).toBe(0);
     });
 });
 


### PR DESCRIPTION
Baut auf PR #48 auf (dessen Commits sind enthalten, Urheberschaft ist im Changelog und im Script-Header vermerkt).

## Was sich ändert

Das Batch-Overlay geht von "alles Alte, ein Klick" auf eine bewusste Auswahl über:

- **Alle Anzeigen** stehen zur Wahl, nicht mehr nur die älter als 7 Tage.
- **Nichts ist vorangehakt.** Mit frischen Anzeigen in der Liste wäre eine Vorauswahl ein scharfes Messer — ein Klick auf Start würde jede Anzeige löschen und neu anlegen.
- **Schnellwahl**: "Alle", "Keine", "älter als 7 Tage", "älter als 14 Tage". Jede *ersetzt* die bestehende Auswahl.
- **Farbcodierung nach Alter**: dunkelgrün ab 14 Tagen, grün 7–13, gelb 5–6, rot bis 4 Tage.
- Button heißt jetzt "Anzeigen auswählen & neu einstellen".

## Zwei bewusste Entscheidungen

**Farbe ist nie die einzige Information.** Neben jedem Farbpunkt steht "N Tage alt" — sonst wäre die Liste bei Rot-Grün-Sehschwäche unbrauchbar.

**Das Alter ist abgeleitet, nicht gemessen.** Die Kartenliste nennt nur das Enddatum, kein Erstelldatum; gerechnet wird `60 − Restlaufzeit`. Dieselbe Annahme steckt seit jeher in `MIN_DAYS_TO_END = 53`. Bei verlängerten Anzeigen ist das ungenau — die Legende im Overlay sagt das offen, statt eine Genauigkeit vorzutäuschen, die die Daten nicht hergeben.

## Verifikation

Live gegen die echte Anzeigenliste geprüft, rein lesend — **Start wurde nie geklickt**, es wurde nichts gelöscht oder neu eingestellt:

| Prüfung | Ergebnis |
|---|---|
| Beim Öffnen | 4 Einträge, 0 angehakt, Start gesperrt |
| "Alle" | 4 von 4, Start frei |
| "älter als 7/14 Tage" | 0 — korrekt, alle Anzeigen sind 0 Tage alt |
| "Keine" | räumt ab, Start gesperrt |
| Einzelne Checkbox | 1 von 4, Start frei |
| Farbband + Alterstext | rot / "0 Tage alt", stimmig |

Dazu 11 neue Unit-Tests (Altersableitung, Bandgrenzen bei 4/5, 6/7, 13/14, Schnellwahl, leere Vorauswahl, Farbbänder), Suite gesamt **64 grün**, `npm run validate` sauber.

## Version und Reihenfolge

3.7.1 → **3.8.0** / Helper 1.5.0 → **1.7.0**. Minor, weil Feature; die Changelog-Konvention führt jede Version als "Version X.Y.Z / Helper A.B.C".

⚠️ **PR #51 trägt noch 3.7.2.** Geht dieser PR zuerst nach main, ist 3.7.2 ein Rückschritt — #51 müsste dann auf 3.8.1 umgestellt werden. Sauber ist: erst #51, dann dieser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)