### PR TITLE
fix: adId-Parsing, Formular-Scoping und Barrierefreiheit (v3.8.1)

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -22,8 +22,9 @@ Buttons "Duplizieren" und "Smart neu einstellen" hinzu.
 
 [Helper-Script installieren](https://github.com/OldRon1977/Kleinanzeigen-Anzeigen-duplizieren/raw/main/helper.user.js)
 
-Fügt auf der "Meine Anzeigen"-Seite den Button "Smart neu einstellen"
-direkt neben jeder Anzeige hinzu, inklusive Batch-Modus.
+Fügt auf der "Meine Anzeigen"-Seite die Buttons "Duplizieren" und
+"Smart neu einstellen" direkt neben jeder Anzeige hinzu, dazu den Batch
+mit Auswahl über der Liste.
 
 ## Manuelle Installation (Alternative)
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ Ein UserScript für Tampermonkey, das praktische Buttons zum Duplizieren und int
 - **Smart neu einstellen**: Löscht das Original und erstellt eine neue Anzeige
 - **Automatische Bilderhaltung**: Alle Bilder bleiben bei beiden Funktionen erhalten
 - **Banner & Popup-Blocker**: Blendet störende Upsell-Banner und Popups automatisch aus
-- **Helper-Script**: Buttons direkt auf der "Meine Anzeigen"-Seite
+- **Helper-Script**: Buttons "Duplizieren" und "Smart neu einstellen" direkt auf der "Meine Anzeigen"-Seite
+- **Batch mit Auswahl**: Mehrere Anzeigen in einem Durchgang neu einstellen — ausgewählt per Checkbox, mit Farbcodierung nach Alter
+- **Recovery-Snapshot**: Vor jeder Löschung werden Texte, Felder und Bilder lokal gesichert
 - **Fehlerbehandlung**: Timeout-Schutz und Retry-Mechanismen
 
 ## Installation
@@ -28,7 +30,7 @@ Fügt auf der **Bearbeiten-Seite** einer Anzeige die Buttons "Duplizieren" und "
 
 [![Install Helper](https://img.shields.io/badge/Install-Helper_Script-0077cc?style=for-the-badge&logo=tampermonkey)](https://github.com/OldRon1977/Kleinanzeigen-Anzeigen-duplizieren/raw/main/helper.user.js)
 
-Fügt auf der **Meine Anzeigen**-Seite neben jeder Anzeige den Button "Smart neu einstellen" hinzu. Ein Klick öffnet die Bearbeiten-Seite und führt die Aktion automatisch aus.
+Fügt auf der **Meine Anzeigen**-Seite neben jeder Anzeige die Buttons "Duplizieren" und "Smart neu einstellen" hinzu. Ein Klick öffnet die Bearbeiten-Seite und führt die Aktion automatisch aus. Dazu kommt der Batch über der Anzeigenliste.
 
 > **Hinweis**: Beide Scripts müssen in Tampermonkey aktiviert sein, damit der Helper korrekt funktioniert.
 
@@ -43,17 +45,20 @@ Beide Scripts erhalten automatisch Updates über Tampermonkey.
 3. **Duplizieren**: Erstellt eine Kopie, Original bleibt bestehen
 4. **Smart neu einstellen**: Löscht Original, erstellt neue Anzeige
 
-### über die Meine-Anzeigen-Seite (Helper)
+### Über die Meine-Anzeigen-Seite (Helper)
 1. Öffne "Meine Anzeigen" auf kleinanzeigen.de
-2. Neben jedem "Bearbeiten"-Link erscheint der Button "Smart neu einstellen"
-3. Ein Klick öffnet die Bearbeiten-Seite und führt die Aktion automatisch aus
+2. Neben jedem "Bearbeiten"-Link erscheinen zwei Buttons: **Duplizieren** (ab Helper v1.5.0) und **Smart neu einstellen**
+3. Ein Klick öffnet die Bearbeiten-Seite in einem neuen Tab und führt die Aktion automatisch aus; nach Erfolg schließt sich der Tab von selbst
 
-### Batch-Modus (Helper ab v1.3.0)
+### Batch mit Auswahl (Helper ab v1.7.0)
 1. Öffne "Meine Anzeigen" auf kleinanzeigen.de
-2. Über der Anzeigenliste erscheint der Batch-Button
-3. Das Bestätigungs-Overlay listet alle Anzeigen auf, die älter als 7 Tage sind — **alle vorausgewählt**
-4. Ab Helper v1.6.0: Einzelne Anzeigen lassen sich abwählen (Checkbox), z.B. Daueranzeigen wie Dienstleistungen. "Alle" / "Keine" setzen die komplette Auswahl. Zusammenfassung und geschätzte Laufzeit aktualisieren sich mit
-5. **Start** verarbeitet nur die angehakten Anzeigen nacheinander, mit 3 ± 1 Minuten Pause. Vor jeder Löschung wird ein Recovery-Snapshot in IndexedDB abgelegt
+2. Über der Anzeigenliste erscheint der Button **"Anzeigen auswählen & neu einstellen"**
+3. Das Overlay listet **alle** Anzeigen mit Checkbox. Beim Öffnen ist **nichts angehakt** — ein versehentlicher Start kann also nichts löschen
+4. **Schnellwahl** unter der Liste: "Alle", "Keine", "älter als 7 Tage", "älter als 14 Tage". Jede Schnellwahl *ersetzt* die bestehende Auswahl
+5. **Farbcodierung** nach Alter: dunkelgrün ab 14 Tagen, grün 7–13 Tage, gelb 5–6 Tage, rot bis 4 Tage. Das Alter steht zusätzlich als Text neben jedem Eintrag
+6. **Start** verarbeitet die angehakten Anzeigen nacheinander, mit 3 ± 1 Minuten Pause. Vor jeder Löschung wird ein Recovery-Snapshot in IndexedDB abgelegt
+
+> **Zum Alter**: Die Anzeigenliste nennt nur das Enddatum, kein Erstelldatum. Das Alter wird daher aus der Restlaufzeit abgeleitet (60 Tage Regellaufzeit) — bei verlängerten Anzeigen ist es ungenau. Die Legende im Overlay weist darauf hin.
 
 ### Banner & Popup-Blocker (ab v3.4.0)
 Das Script blendet automatisch aus:
@@ -109,6 +114,7 @@ Hauptscript verwendet `@grant none`. Helper-Script verwendet ab v1.3.0 `@grant G
 - **Fix**: Die `adId` wird über `URLSearchParams` statt per Regex aus der URL gelesen. Das bisherige Muster kannte keine Parametergrenze und hätte auch in `?myadId=123` getroffen. Die Ziffernprüfung bleibt, weil der Wert in Fetch-URLs und Storage-Schlüssel wandert.
 - **Fix**: `readFormFields()` liest nur noch innerhalb des Anzeigen-Formulars statt im ganzen Dokument — Felder aus Suchleiste, Newsletter-Box oder Cookie-Bannern landen damit nicht mehr im Snapshot. Ohne auffindbares Formular bleibt das bisherige Verhalten als Rückfallebene.
 - **Barrierefreiheit**: Meldungen sind jetzt Live-Regionen (`role="status"` / bei Fehlern `role="alert"`), sodass Screenreader sie ohne Fokuswechsel vorlesen. Die Toolbar-Buttons haben `aria-label`, die die Konsequenz des Klicks nennen statt nur den Namen.
+- **Doku**: README, INSTALL und SECURITY auf den aktuellen Stand gebracht — der Duplizieren-Button auf "Meine Anzeigen" (seit Helper 1.5.0) fehlte in der Anleitung ganz, der Batch-Abschnitt beschrieb noch die alte Vorauswahl.
 
 ### Version 3.8.0 / Helper 1.7.0 (August 2026)
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,12 @@ Hauptscript verwendet `@grant none`. Helper-Script verwendet ab v1.3.0 `@grant G
 
 ## Changelog
 
+### Version 3.8.1 (August 2026)
+
+- **Fix**: Die `adId` wird über `URLSearchParams` statt per Regex aus der URL gelesen. Das bisherige Muster kannte keine Parametergrenze und hätte auch in `?myadId=123` getroffen. Die Ziffernprüfung bleibt, weil der Wert in Fetch-URLs und Storage-Schlüssel wandert.
+- **Fix**: `readFormFields()` liest nur noch innerhalb des Anzeigen-Formulars statt im ganzen Dokument — Felder aus Suchleiste, Newsletter-Box oder Cookie-Bannern landen damit nicht mehr im Snapshot. Ohne auffindbares Formular bleibt das bisherige Verhalten als Rückfallebene.
+- **Barrierefreiheit**: Meldungen sind jetzt Live-Regionen (`role="status"` / bei Fehlern `role="alert"`), sodass Screenreader sie ohne Fokuswechsel vorlesen. Die Toolbar-Buttons haben `aria-label`, die die Konsequenz des Klicks nennen statt nur den Namen.
+
 ### Version 3.8.0 / Helper 1.7.0 (August 2026)
 
 Das Batch-Overlay ist von "alles Alte, ein Klick" auf eine bewusste Auswahl umgestellt.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,8 +4,8 @@
 
 | Version       | Unterstuetzt |
 |---------------|--------------|
-| 3.6.x / 1.4.x | Ja           |
-| < 3.6         | Nein         |
+| 3.8.x / 1.7.x | Ja           |
+| < 3.8         | Nein         |
 
 ## Schwachstelle melden
 

--- a/kleinanzeigen-duplizieren.user.js
+++ b/kleinanzeigen-duplizieren.user.js
@@ -5,7 +5,7 @@
 // @icon          https://www.kleinanzeigen.de/favicon.ico
 // @copyright     2026
 // @license       MIT
-// @version       3.8.0
+// @version       3.8.1
 // @author        OldRon1977 (Improvements), J05HI (Original)
 // @credits       Basierend auf dem Original-Script von J05HI (https://gist.github.com/J05HI/9f3fc7a496e8baeff5a56e0c1a710bb5)
 // @match         https://www.kleinanzeigen.de/p-anzeige-bearbeiten.html*
@@ -35,7 +35,7 @@
 (function () {
     'use strict';
 
-    const SCRIPT_VERSION = '3.8.0'; // wird von scripts/build.js synchron zu package.json gehalten
+    const SCRIPT_VERSION = '3.8.1'; // wird von scripts/build.js synchron zu package.json gehalten
 
     // === KONSTANTEN ===
     const CONFIG = {
@@ -161,6 +161,11 @@
 
         const notification = document.createElement('div');
         notification.className = `ka-notification ${type}`;
+        // Ohne Live-Region bleibt die Meldung fuer Screenreader unsichtbar --
+        // sie erscheint ohne Fokuswechsel irgendwo am Bildschirmrand. Fehler
+        // unterbrechen (assertive), normale Hinweise warten (polite).
+        notification.setAttribute('role', type === 'error' ? 'alert' : 'status');
+        notification.setAttribute('aria-live', type === 'error' ? 'assertive' : 'polite');
         notification.textContent = message;
 
         document.body.appendChild(notification);
@@ -330,10 +335,18 @@
     // -> name="adId"), deshalb ist die Liste kumulativ.
     const AD_ID_SELECTOR = 'input[name="adId"], #postad-id, input[name="postad-id"], input[name="id"]';
 
+    // Liest die adId aus der Query. Bewusst ueber URLSearchParams statt per
+    // Regex: ein Muster wie /adId=(\d+)/ kennt keine Parametergrenze und wuerde
+    // auch in "?myadId=123" treffen. Die Ziffernpruefung bleibt, weil der Wert
+    // in Fetch-URLs und Storage-Schluessel wandert.
     function getUrlAdId(loc) {
         const search = (loc || window.location).search || '';
-        const m = search.match(/adId=(\d+)/);
-        return m ? m[1] : null;
+        try {
+            const value = new URLSearchParams(search).get('adId');
+            return value && /^\d{1,20}$/.test(value) ? value : null;
+        } catch (e) {
+            return null;
+        }
     }
 
     /**
@@ -576,10 +589,26 @@
 
     function isBatchMode() { return window.location.hash === '#smartRepublish'; }
 
-    function readFormFields() {
+    /**
+     * Wurzel fuer alle Formular-Lesevorgaenge: das Formular der Anzeige, nicht
+     * das ganze Dokument. Sonst landen Felder aus Suchleiste, Newsletter-Box
+     * oder Cookie-Bannern im Snapshot. Bevorzugt wird das Formular, in dem das
+     * Ad-ID-Feld haengt; erst wenn das nicht aufloesbar ist, wird auf das erste
+     * Formular und zuletzt auf das Dokument zurueckgefallen -- damit wird die
+     * Erfassung nie schlechter als vorher.
+     */
+    function getAdFormRoot(doc, urlAdId) {
+        const d = doc || document;
+        const adIdInput = findAdIdInput(d, urlAdId !== undefined ? urlAdId : getUrlAdId());
+        if (adIdInput && adIdInput.form) return adIdInput.form;
+        return d.querySelector('form') || d;
+    }
+
+    function readFormFields(doc, urlAdId) {
         const fields = {};
         const rawFields = {};
-        document.querySelectorAll('input, textarea, select').forEach(function (el) {
+        const root = getAdFormRoot(doc, urlAdId);
+        root.querySelectorAll('input, textarea, select').forEach(function (el) {
             const name = el.getAttribute('name');
             if (!name) return;
             if (el.type === 'checkbox' || el.type === 'radio') {
@@ -596,15 +625,15 @@
             if (v === undefined || v === null || v === '') return;
             rawFields[name] = String(v).slice(0, 5000);
         });
-        const titleInput = document.querySelector('input[name="title"], input#title');
+        const titleInput = root.querySelector('input[name="title"], input#title');
         if (titleInput) fields.title = titleInput.value;
-        const descTa = document.querySelector('textarea[name="description"], textarea#description');
+        const descTa = root.querySelector('textarea[name="description"], textarea#description');
         if (descTa) fields.description = descTa.value;
-        const priceInput = document.querySelector('input[name="price"], input#price');
+        const priceInput = root.querySelector('input[name="price"], input#price');
         if (priceInput) fields.price = priceInput.value;
-        const priceTypeSel = document.querySelector('select[name="priceType"], select#priceType');
+        const priceTypeSel = root.querySelector('select[name="priceType"], select#priceType');
         if (priceTypeSel) fields.priceType = priceTypeSel.value;
-        const locInput = document.querySelector('input[name="locationStr"], input#locationStr, input[name="zipCode"]');
+        const locInput = root.querySelector('input[name="locationStr"], input#locationStr, input[name="zipCode"]');
         if (locInput) fields.location = locInput.value;
         return { fields: fields, rawFields: rawFields };
     }
@@ -841,6 +870,8 @@
 
         const toolbar = document.createElement('div');
         toolbar.id = TOOLBAR_ID;
+        toolbar.setAttribute('role', 'toolbar');
+        toolbar.setAttribute('aria-label', 'Anzeige duplizieren oder neu einstellen');
         toolbar.style.cssText = [
             'position:fixed',
             'bottom:20px',
@@ -859,12 +890,16 @@
         dupButton.className = 'ka-duplicate-btn';
         dupButton.textContent = 'Duplizieren';
         dupButton.title = 'Erstellt eine Kopie, Original bleibt erhalten';
+        // title allein wird von Screenreadern nicht zuverlaessig vorgelesen;
+        // aria-label traegt die Konsequenz des Klicks, nicht nur den Namen.
+        dupButton.setAttribute('aria-label', 'Anzeige duplizieren - erstellt eine Kopie, das Original bleibt erhalten');
 
         const smartButton = document.createElement('button');
         smartButton.type = 'button';
         smartButton.className = 'ka-smart-btn';
         smartButton.textContent = 'Smart neu einstellen';
         smartButton.title = 'Löscht Original und erstellt neue Anzeige';
+        smartButton.setAttribute('aria-label', 'Smart neu einstellen - löscht das Original und erstellt eine neue Anzeige');
 
         dupButton.onclick = (e) => {
             e.preventDefault();
@@ -961,7 +996,7 @@
     if (typeof module !== 'undefined' && module.exports &&
         typeof process !== 'undefined' && process.versions && process.versions.node) {
         module.exports = {
-            CONFIG, getExponentialBackoffWait, readFormFields, collectImageUrls,
+            CONFIG, getExponentialBackoffWait, readFormFields, getAdFormRoot, collectImageUrls,
             findAdIdInput, describeAdIdLookup, describeAdIdResolution, getUrlAdId
         };
         return; // im Test-Kontext keine Initialisierung/Timer

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kleinanzeigen-anzeigen-duplizieren",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "helperVersion": "1.7.0",
   "description": "eBay Kleinanzeigen - Anzeige duplizieren / neu einstellen. Einfaches Duplizieren und Smart Neu-Einstellen von Anzeigen mit automatischer Bilderhaltung",
   "main": "kleinanzeigen-duplizieren.user.js",

--- a/tests/worker.adid.test.js
+++ b/tests/worker.adid.test.js
@@ -18,6 +18,23 @@ describe('getUrlAdId', () => {
         expect(getUrlAdId({ search: '?foo=1' })).toBeNull();
         expect(getUrlAdId({ search: '' })).toBeNull();
     });
+
+    it('trifft nicht auf Parameter, die nur auf adId enden', () => {
+        // Die frueher genutzte Regex /adId=(\d+)/ kannte keine Parametergrenze
+        // und lieferte hier faelschlich "123".
+        expect(getUrlAdId({ search: '?myadId=123' })).toBeNull();
+        expect(getUrlAdId({ search: '?foo=1&otheradId=999' })).toBeNull();
+    });
+
+    it('findet die adId unabhaengig von der Parameter-Reihenfolge', () => {
+        expect(getUrlAdId({ search: '?foo=1&adId=3485590892&bar=2' })).toBe(AD_ID);
+    });
+
+    it('weist nicht-numerische Werte ab', () => {
+        expect(getUrlAdId({ search: '?adId=abc' })).toBeNull();
+        expect(getUrlAdId({ search: '?adId=' })).toBeNull();
+        expect(getUrlAdId({ search: '?adId=12345678901234567890123' })).toBeNull();
+    });
 });
 
 describe('findAdIdInput - bekannte Selektoren', () => {

--- a/tests/worker.dom.test.js
+++ b/tests/worker.dom.test.js
@@ -5,6 +5,7 @@ const {
     CONFIG,
     getExponentialBackoffWait,
     readFormFields,
+    getAdFormRoot,
     collectImageUrls
 } = worker;
 
@@ -105,5 +106,47 @@ describe('collectImageUrls', () => {
         expect(collectImageUrls()).toEqual([
             'https://img.kleinanzeigen.de/api/v1/prod-ads/images/xx?rule=$_57.JPG'
         ]);
+    });
+});
+
+describe('getAdFormRoot / readFormFields - Formular-Scoping', () => {
+    it('waehlt das Formular, in dem das adId-Feld haengt', () => {
+        document.body.innerHTML = `
+            <form id="suche"><input name="query" value="fahrrad"></form>
+            <form id="anzeige">
+                <input type="hidden" name="adId" value="3485590892">
+                <input name="title" value="Mein Titel">
+            </form>
+        `;
+        expect(getAdFormRoot(document, '3485590892').id).toBe('anzeige');
+    });
+
+    it('erfasst keine Felder ausserhalb des Anzeigen-Formulars', () => {
+        document.body.innerHTML = `
+            <input name="globales-feld" value="nicht erfassen">
+            <form id="suche"><input name="query" value="fahrrad"></form>
+            <form id="anzeige">
+                <input type="hidden" name="adId" value="3485590892">
+                <input name="title" value="Mein Titel">
+                <textarea name="description">Beschreibung</textarea>
+            </form>
+        `;
+        const { fields, rawFields } = readFormFields(document, '3485590892');
+
+        expect(rawFields.title).toBe('Mein Titel');
+        expect(fields.description).toBe('Beschreibung');
+        expect(rawFields.query).toBeUndefined();
+        expect(rawFields['globales-feld']).toBeUndefined();
+    });
+
+    it('faellt auf das erste Formular zurueck, wenn kein adId-Feld da ist', () => {
+        document.body.innerHTML = `<form id="erstes"><input name="title" value="T"></form>`;
+        expect(getAdFormRoot(document, null).id).toBe('erstes');
+        expect(readFormFields(document, null).rawFields.title).toBe('T');
+    });
+
+    it('faellt auf das Dokument zurueck, wenn es gar kein Formular gibt', () => {
+        document.body.innerHTML = `<input name="title" value="Ohne Formular">`;
+        expect(readFormFields(document, null).rawFields.title).toBe('Ohne Formular');
     });
 });


### PR DESCRIPTION
Aus einem externen Review-Vorschlag zu 3.8.0 übernommen — die drei Punkte, die einer Prüfung standhielten.

## Änderungen

**1. `getUrlAdId` über `URLSearchParams`.** Das bisherige `/adId=(\d+)/` kennt keine Parametergrenze. Verifiziert:

```
?foo=1&myadId=123  →  Regex: "123"   URLSearchParams: null
```

Heute praktisch folgenlos (die URL ist `?adId=…`), aber umsonst zu haben. Die Ziffernprüfung bleibt, weil der Wert in Fetch-URLs und Storage-Schlüssel wandert.

**2. `readFormFields` liest nur noch im Anzeigen-Formular.** Aufgelöst über das Formular des adId-Felds, mit Rückfall auf das erste Formular und zuletzt aufs Dokument — die Erfassung wird dadurch nie schlechter als vorher. Ehrlich dazu: Auf der heutigen Seite liegen **alle 35 Felder ohnehin im Formular**, die Änderung behebt also kein beobachtetes Leck, sondern schließt den Weg für Suchleisten-, Newsletter- und Banner-Felder.

**3. Barrierefreiheit.** Meldungen sind Live-Regionen (`role="status"`, bei Fehlern `role="alert"` + `aria-live="assertive"`), Toolbar-Buttons haben `aria-label`, die die *Konsequenz* nennen statt nur den Namen — bei "Smart neu einstellen" ist das der Unterschied zwischen "Kopie" und "Original wird gelöscht".

## Was aus dem Vorschlag bewusst nicht übernommen wurde

| Vorschlag | Grund |
|---|---|
| Popup-Polling → MutationObserver | Öffnet Issue #39 wieder: das Modal rendert Buttons vor den Handlern, ein früher Klick verpufft — und danach mutiert nichts mehr, es gäbe keinen zweiten Trigger. Der Reclick mit Cooldown ist der Fix. |
| "Exaktes Text-Matching vermeiden" | Dreht die Härtung aus v3.5.1 zurück. Der Match ist bewusst exakt und auf `[role="dialog"]` beschränkt, damit während der `save-clicked`-Phase — Original bereits gelöscht — kein falscher Button getroffen wird. |
| Nur Bild-URLs speichern statt Blobs | Zerstört den Zweck des Snapshots: Er sichert genau den Fall ab, dass die Anzeige gelöscht wird. Danach sind die URLs tot. |
| `history.pushState` patchen | Invasiv; die Bearbeiten-Seite lädt real neu (gemessen), es gibt keine SPA-Navigation zu behandeln. |
| Logging hinter `debug`-Flag | Die Konsolenausgabe war bei #49 die einzige Diagnosequelle. |
| `querySelectorAll`-Ergebnisse cachen | Referenzen werden wegen React-Re-Renders bewusst neu aufgelöst (`isConnected`). |

Ebenfalls vorgeschlagen und bereits vorhanden: Tests, CI, Versions-Sync, Changelog, Privacy-Doku und ein Lösch-Knopf für Snapshots.

## Verifikation

Live auf der Bearbeiten-Seite, rein lesend — nichts gespeichert, nichts dupliziert:

```
toolbar:      role=toolbar, aria-label gesetzt, beide Buttons mit aria-label
notification: role=status, aria-live=polite
scoping:      Formular aufgelöst, 35 Felder dokumentweit = 35 im Formular
```

7 neue Unit-Tests (Parametergrenze, Reihenfolge, nicht-numerische Werte, Formular-Auswahl und beide Rückfallebenen), Suite gesamt **73 grün**, `npm run validate` sauber.

## Version

3.8.0 → **3.8.1** (Patch, Helper unverändert bei 1.7.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)