### PR TITLE
Anzeigenliste zwischenspeichern (Helper 1.11.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,12 @@ Hauptscript verwendet `@grant none`. Helper-Script verwendet ab v1.3.0 `@grant G
 
 ## Changelog
 
+### Helper 1.11.0 (August 2026)
+
+- **Neu**: Die Anzeigenliste wird 90 Sekunden zwischengespeichert. Bisher löste jedes Öffnen des Batch-Fensters einen kompletten Abruf über alle Seiten aus — bei über 25 Anzeigen mehrere Anfragen pro Klick. Das ist reine Rücksicht auf die Serverlast; für dich ändert sich nur, dass das Fenster schneller aufgeht.
+- Die Herkunft der Liste steht jetzt im Fenster ("frisch geladen" / "zwischengespeichert (12s alt)") samt **Neu laden**-Link, falls du bewusst den aktuellen Stand willst.
+- Der Zwischenspeicher wird automatisch verworfen, sobald sich die Liste geändert haben muss: nach einem Batch-Lauf, nach einem einzelnen Neu-Einstellen und nach einem Duplizieren. Die Rückfallebene über die Seitenansicht wird **nicht** zwischengespeichert — sie kostet kein Netz und spiegelt ohnehin die sichtbare Seite.
+
 ### Helper 1.10.0 (August 2026)
 
 Die Pause zwischen zwei Anzeigen im Batch ist einstellbar, statt fest im Script zu stehen.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,8 +4,8 @@
 
 | Version       | Unterstuetzt |
 |---------------|--------------|
-| 3.10.x / 1.9.x | Ja          |
-| < 3.10         | Nein        |
+| 3.10.x / 1.11.x | Ja         |
+| < 3.10          | Nein       |
 
 ## Schwachstelle melden
 

--- a/helper.user.js
+++ b/helper.user.js
@@ -5,7 +5,7 @@
 // @icon          https://www.kleinanzeigen.de/favicon.ico
 // @copyright     2026
 // @license       MIT
-// @version       1.10.0
+// @version       1.11.0
 // @author        panzli (Original), OldRon1977 (Anpassungen)
 // @credits       karlvonbonin - Idee und Grundlage der Auswahl im Batch-Overlay (PR #48)
 // @credits       Andi (Zer089) - Alter der Anzeige in Tagen mit Farbcode als Auswahlhilfe, Dashboard-Ansicht: https://github.com/Zer089/Kleinanzeigen.de-Anzeige_duplizieren_neu_einstellen
@@ -44,6 +44,47 @@
         { key: 'mittel', minAge: 5, color: '#f9a825', label: '5-6 Tage' },
         { key: 'frisch', minAge: 0, color: '#e53935', label: 'bis 4 Tage' }
     ];
+
+    // Kurzzeit-Cache fuer die Anzeigenliste. Ohne ihn holt jedes Oeffnen des
+    // Batch-Fensters die komplette Liste neu -- bei ueber 25 Anzeigen also
+    // mehrere Abrufe pro Klick. 90 Sekunden fangen mehrfaches Oeffnen
+    // hintereinander ab, ohne dass die Liste sichtbar veraltet.
+    const AD_LIST_CACHE_MS = 90 * 1000;
+
+    // Bewusst nur im Speicher und nicht in localStorage: Nach einem Batch-Lauf
+    // -- womoeglich in einem anderen Tab -- waere ein persistierter Stand
+    // schlicht falsch, und niemand erwartet nach einem Reload alte Daten.
+    let adListCache = null;   // { at: <ms>, result: <Ergebnis von collect...> }
+
+    function invalidateAdListCache() {
+        if (adListCache) log('Anzeigenliste im Cache verworfen');
+        adListCache = null;
+    }
+
+    function cachedAdListAgeMs() {
+        return adListCache ? (Date.now() - adListCache.at) : null;
+    }
+
+    // Flache Kopie des Sammel-Ergebnisses. Wird in BEIDE Richtungen benutzt:
+    // beim Ablegen und beim Herausgeben. Sonst teilt sich der erste, noch
+    // ungecachte Rueckgabewert die Arrays mit dem Cache -- und wer daran etwas
+    // aendert, veraendert unbemerkt den naechsten Aufruf.
+    function cloneCollectResult(result) {
+        return {
+            matches: result.matches.map(function (m) { return Object.assign({}, m); }),
+            skipped: result.skipped.slice(),
+            source: result.source
+        };
+    }
+
+    function readAdListCache() {
+        if (!adListCache) return null;
+        if (cachedAdListAgeMs() > AD_LIST_CACHE_MS) {
+            adListCache = null;
+            return null;
+        }
+        return adListCache.result;
+    }
 
     // Anzeigenliste als JSON. Liefert im Gegensatz zum DOM das echte
     // Erstelldatum, den Merk-Zaehler als Zahl und ALLE Seiten -- das DOM kennt
@@ -397,6 +438,9 @@
             clearTimeout(timeoutId);
             try { localStorage.removeItem(lsKey); } catch (e) {}
             try { tabHandle.close(); } catch (e) {}
+            // Es gibt eine Anzeige mehr -- ein zwischengespeicherter Stand
+            // waere ab jetzt unvollstaendig.
+            invalidateAdListCache();
             button.style.color = '#27ae60';
             button.textContent = '✅ Dupliziert';
             setTimeout(function () {
@@ -435,6 +479,10 @@
         button.textContent = '\u23F3 Laeuft \u2026';
         processOne({ adId: adId, title: '' }).then(function (res) {
             if (res.ok) {
+                // Diese Anzeige gibt es nicht mehr, dafuer eine neue mit anderer
+                // ID. Der Cache muss weg, sonst bietet das Overlay eine geloeschte
+                // Anzeige zum Neu-Einstellen an.
+                invalidateAdListCache();
                 button.style.color = '#27ae60';
                 button.textContent = '\u2705 Fertig';
                 deleteSnapshot(adId).catch(function () {});
@@ -615,10 +663,32 @@
     // das echte Erstelldatum; faellt sie aus (Schnittstelle geaendert, nicht
     // eingeloggt, Netzfehler), arbeitet der Batch wie bisher mit dem DOM
     // weiter -- dann eben nur mit der sichtbaren Seite und geschaetztem Alter.
-    async function collectCandidatesResilient() {
+    async function collectCandidatesResilient(options) {
+        const force = !!(options && options.force);
+
+        if (!force) {
+            const hit = readAdListCache();
+            if (hit) {
+                const ageSec = Math.round(cachedAdListAgeMs() / 1000);
+                log('Anzeigenliste aus dem Cache (' + ageSec + 's alt)');
+                const copy = cloneCollectResult(hit);
+                copy.fromCache = true;
+                copy.ageSeconds = ageSec;
+                return copy;
+            }
+        }
+
         try {
             const viaJson = await collectCandidatesJson();
-            if (viaJson.matches.length > 0) return viaJson;
+            if (viaJson.matches.length > 0) {
+                // Nur die JSON-Quelle wird gehalten. Der DOM-Weg kostet kein
+                // Netz und spiegelt ohnehin genau die sichtbare Seite -- ihn zu
+                // cachen brächte nichts und könnte veralten.
+                // Kopie ablegen, Original herausgeben: Was der Aufrufer damit
+                // macht, darf den Cache nicht beruehren.
+                adListCache = { at: Date.now(), result: cloneCollectResult(viaJson) };
+                return viaJson;
+            }
             warn('JSON-Quelle lieferte keine Anzeigen – falle auf die Seitenansicht zurück');
         } catch (e) {
             warn('JSON-Quelle nicht verfügbar – falle auf die Seitenansicht zurück', e);
@@ -874,7 +944,7 @@
             : 'ca. ' + range.minMinutes + '-' + range.maxMinutes + ' Minuten';
     }
 
-    async function renderConfirm(matches, skipped, onStart) {
+    async function renderConfirm(matches, skipped, onStart, meta) {
         const overlay = ensureOverlay();
 
         overlay.innerHTML = '';
@@ -916,6 +986,35 @@
         const line2 = document.createElement('div');
         line2.style.cssText = 'color:#666;margin-top:4px;';
         summary.appendChild(line2);
+
+        // Herkunft der Liste offenlegen. Wer eine Anzeige in einem anderen Tab
+        // geaendert hat, soll sehen, dass hier ein zwischengespeicherter Stand
+        // steht -- und ihn mit einem Klick auffrischen koennen.
+        if (meta && meta.onReload) {
+            const line3 = document.createElement('div');
+            line3.style.cssText = 'color:#999;margin-top:4px;font-size:11px;display:flex;gap:6px;align-items:center;flex-wrap:wrap;';
+            const label = document.createElement('span');
+            if (meta.fromCache) {
+                label.textContent = 'Liste zwischengespeichert (' + (meta.ageSeconds || 0) + 's alt).';
+            } else {
+                label.textContent = meta.source === 'json'
+                    ? 'Liste frisch geladen.'
+                    : 'Liste aus der Seitenansicht – nur die sichtbare Seite.';
+            }
+            const reload = document.createElement('button');
+            reload.type = 'button';
+            reload.textContent = 'Neu laden';
+            reload.style.cssText = 'background:none;border:none;padding:0;color:#007bff;cursor:pointer;font-size:11px;text-decoration:underline;';
+            reload.onclick = function () {
+                reload.disabled = true;
+                reload.textContent = 'Lädt \u2026';
+                meta.onReload();
+            };
+            line3.appendChild(label);
+            line3.appendChild(reload);
+            summary.appendChild(line3);
+        }
+
         overlay.appendChild(summary);
 
         const list = document.createElement('ul');
@@ -1485,16 +1584,22 @@
     // === ORCHESTRATOR ===
     let stopRequested = false;
 
-    async function startBatchFlow() {
-        const result = await collectCandidatesResilient();
+    async function startBatchFlow(options) {
+        const result = await collectCandidatesResilient(options);
         log('Kandidaten:', {
             matches: result.matches.length,
             skipped: result.skipped.length,
-            quelle: result.source
+            quelle: result.source,
+            ausCache: !!result.fromCache
         });
         await renderConfirm(result.matches, result.skipped, function (matches, delayCfg) {
             stopRequested = false;
             runBatch(matches, delayCfg);
+        }, {
+            source: result.source,
+            fromCache: !!result.fromCache,
+            ageSeconds: result.ageSeconds || 0,
+            onReload: function () { startBatchFlow({ force: true }); }
         });
     }
 
@@ -1704,6 +1809,9 @@
             }
         }
 
+        // Nach einem Lauf stimmt die zwischengespeicherte Liste garantiert nicht
+        // mehr: verarbeitete Anzeigen sind geloescht und durch neue ersetzt.
+        invalidateAdListCache();
         log('Batch fertig', { ok: state.processed.length, fail: state.failed.length, aborted: state.aborted, autoStopped: state.autoStopped });
         renderDone(state);
     }
@@ -1733,6 +1841,8 @@
             fetchAdListJson,
             collectCandidatesJson,
             collectCandidatesResilient,
+            invalidateAdListCache,
+            AD_LIST_CACHE_MS,
             collectCandidates,
             daysUntil,
             ageFromDaysLeft,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kleinanzeigen-anzeigen-duplizieren",
   "version": "3.10.0",
-  "helperVersion": "1.10.0",
+  "helperVersion": "1.11.0",
   "description": "eBay Kleinanzeigen - Anzeige duplizieren / neu einstellen. Einfaches Duplizieren und Smart Neu-Einstellen von Anzeigen mit automatischer Bilderhaltung",
   "main": "kleinanzeigen-duplizieren.user.js",
   "scripts": {

--- a/tests/helper.jsonsource.test.js
+++ b/tests/helper.jsonsource.test.js
@@ -1,7 +1,11 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
 import helper from '../helper.user.js';
 
 const {
+    invalidateAdListCache,
+    AD_LIST_CACHE_MS,
     ageFromJsonAd,
     parseJsonDate,
     daysSince,
@@ -54,6 +58,8 @@ function mockFetch(pages) {
 
 beforeEach(() => {
     document.body.innerHTML = '';
+    // Der Cache ist Modulzustand und ueberlebt sonst von Test zu Test.
+    invalidateAdListCache();
 });
 
 afterEach(() => {
@@ -236,5 +242,123 @@ describe('collectCandidatesJson', () => {
         const res = await collectCandidatesJson();
         expect(res.matches.map((m) => m.adId)).toEqual(['1']);
         expect(res.skipped).toHaveLength(1);
+    });
+});
+
+describe('Cache der Anzeigenliste', () => {
+    // paging.last: 1 macht ein "Laden" zu genau EINEM fetch -- ohne die Angabe
+    // fragt der Abruf noch die (leere) zweite Seite ab und die Zaehlung waere
+    // doppelt so hoch.
+    const einSeitig = { 1: { ads: [jsonAd({ id: 1 })], paging: { last: 1 } } };
+
+    function domPage() {
+        document.body.innerHTML =
+            '<ul><li data-testid="ad-card" data-adid="99">' +
+            '<h3><a>Aus dem DOM</a></h3>' +
+            '<span class="managead-listitem-enddate">' + inDays(40) + '</span>' +
+            '</li></ul>';
+    }
+
+    it('holt beim zweiten Öffnen nicht erneut', async () => {
+        global.fetch = mockFetch(einSeitig);
+
+        const erst = await collectCandidatesResilient();
+        const zweit = await collectCandidatesResilient();
+
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+        expect(erst.fromCache).toBeFalsy();
+        expect(zweit.fromCache).toBe(true);
+        expect(zweit.matches.map((m) => m.adId)).toEqual(['1']);
+    });
+
+    it('laedt mit force trotzdem neu', async () => {
+        global.fetch = mockFetch(einSeitig);
+
+        await collectCandidatesResilient();
+        const frisch = await collectCandidatesResilient({ force: true });
+
+        expect(global.fetch).toHaveBeenCalledTimes(2);
+        expect(frisch.fromCache).toBeFalsy();
+    });
+
+    it('laedt nach dem Verwerfen neu', async () => {
+        global.fetch = mockFetch(einSeitig);
+
+        await collectCandidatesResilient();
+        invalidateAdListCache();
+        await collectCandidatesResilient();
+
+        expect(global.fetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('laeuft nach der Haltezeit ab', async () => {
+        global.fetch = mockFetch(einSeitig);
+        const jetzt = Date.now();
+        const spy = vi.spyOn(Date, 'now');
+
+        spy.mockReturnValue(jetzt);
+        await collectCandidatesResilient();
+
+        spy.mockReturnValue(jetzt + AD_LIST_CACHE_MS - 1000);
+        expect((await collectCandidatesResilient()).fromCache).toBe(true);
+
+        spy.mockReturnValue(jetzt + AD_LIST_CACHE_MS + 1000);
+        expect((await collectCandidatesResilient()).fromCache).toBeFalsy();
+        expect(global.fetch).toHaveBeenCalledTimes(2);
+
+        spy.mockRestore();
+    });
+
+    it('haelt die DOM-Rueckfallebene NICHT fest', async () => {
+        // Der DOM-Weg kostet kein Netz und spiegelt die sichtbare Seite --
+        // ihn zu cachen brächte nichts und wuerde nur veralten.
+        global.fetch = mockFetch({ 1: new Error('offline') });
+        domPage();
+
+        const erst = await collectCandidatesResilient();
+        const zweit = await collectCandidatesResilient();
+
+        expect(erst.source).toBe('dom');
+        expect(zweit.source).toBe('dom');
+        expect(zweit.fromCache).toBeFalsy();
+        expect(global.fetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('gibt Kopien heraus, nicht den Cache selbst', async () => {
+        global.fetch = mockFetch({ 1: { ads: [jsonAd({ id: 1, title: 'Original' })], paging: { last: 1 } } });
+
+        const erst = await collectCandidatesResilient();
+        erst.matches[0].title = 'VERAENDERT';
+        erst.matches.push({ adId: 'geschmuggelt' });
+
+        const zweit = await collectCandidatesResilient();
+        expect(zweit.matches).toHaveLength(1);
+        expect(zweit.matches[0].title).toBe('Original');
+    });
+});
+
+// Die drei Stellen, an denen der Cache verworfen werden MUSS, weil sich die
+// Anzeigenliste danach garantiert geaendert hat. Ein Verhaltenstest muesste den
+// halben Batch-Lauf nachbauen; diese Struktur-Pruefung haelt bewusst nur die
+// eine Eigenschaft fest, die sonst still verloren ginge.
+describe('Cache wird nach verändernden Aktionen verworfen', () => {
+    const src = fs.readFileSync(path.resolve(process.cwd(), 'helper.user.js'), 'utf8');
+
+    function body(fnName) {
+        const start = src.search(new RegExp('(async )?function ' + fnName + '\\('));
+        expect(start).toBeGreaterThan(-1);
+        return src.slice(start, src.indexOf('\n    }', start));
+    }
+
+    it('nach einem Batch-Lauf', () => {
+        expect(body('runBatch')).toContain('invalidateAdListCache()');
+    });
+
+    it('nach einem einzelnen Neu-Einstellen', () => {
+        expect(body('openSmartRepublish')).toContain('invalidateAdListCache()');
+    });
+
+    it('nach einem Duplizieren', () => {
+        expect(body('openDuplicate')).toContain('invalidateAdListCache()');
     });
 });


### PR DESCRIPTION
Bisher löste **jedes** Öffnen des Batch-Fensters einen kompletten Abruf über alle Seiten aus — bei über 25 Anzeigen mehrere Anfragen pro Klick, für Daten, die sich in der Zwischenzeit nicht geändert haben. Das ist unnötige Last auf fremden Servern.

## Umsetzung

- **90 Sekunden Haltezeit**, bewusst nur im Speicher und nicht in `localStorage`: Nach einem Batch-Lauf — womöglich in einem anderen Tab — wäre ein persistierter Stand falsch, und niemand erwartet nach einem Reload alte Daten.
- **Verworfen** wird der Cache, sobald sich die Liste geändert haben muss: nach einem Batch-Lauf, nach einem einzelnen Neu-Einstellen und nach einem Duplizieren.
- Die **DOM-Rückfallebene wird nicht zwischengespeichert** — sie kostet kein Netz und spiegelt ohnehin genau die sichtbare Seite.
- Das Overlay legt die Herkunft offen ("Liste frisch geladen." / "Liste zwischengespeichert (12s alt).") und bietet einen **Neu laden**-Link für den bewusst frischen Stand.

## Zwei Fehler, die beim Testen aufgefallen sind

- Der **frische** Rückgabewert teilte sich die Arrays mit dem Cache. Geschützt war nur die Lesekopie — übersehen, dass beim ersten Laden dasselbe Objekt herausgeht, das abgelegt wird. Eine Änderung daran hätte unbemerkt den nächsten Aufruf verändert. Jetzt wird in beide Richtungen kopiert.
- Der Cache ist Modulzustand und leckte zwischen den Tests durch; drei bestehende Tests fielen um, weil sie den gecachten JSON-Stand statt der DOM-Rückfallebene bekamen. Die Suite räumt ihn jetzt im `beforeEach` ab.

## Tests

198 Tests, davon 7 neu. Mutationsproben: Ablauf abschalten, `force` ignorieren, Objekt statt Kopie ablegen, und jede der drei Verwerfungs-Stellen einzeln entfernen — jede lässt genau den zuständigen Test fallen. Die drei Verwerfungs-Stellen waren zunächst gar nicht abgedeckt; das fiel erst auf, als eine Mutation folgenlos blieb.

## Live geprüft

Zweites Öffnen des Batch-Fensters ohne Netzabruf:

```
Kandidaten: {matches: 4, skipped: 0, quelle: "json", ausCache: false}
Anzeigenliste aus dem Cache (4s alt)
Kandidaten: {matches: 4, skipped: 0, quelle: "json", ausCache: true}
```

Im Overlay entsprechend "Liste zwischengespeichert (4s alt)."

## Nebenbei

`SECURITY.md` stand noch auf 1.9.x — der Helper-Bump auf 1.10.0 hatte die Tabelle nicht mitgenommen. Jetzt 1.11.x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)