### PR TITLE
refactor: Style-String der Einzel-Buttons ueber BTN_STYLE teilen

### DIFF
--- a/helper.user.js
+++ b/helper.user.js
@@ -366,7 +366,7 @@
             btn.type = 'button';
             btn.textContent = '\uD83D\uDD04 Smart neu einstellen';
             btn.title = 'Löscht Original und erstellt neue Anzeige';
-            btn.style.cssText = 'margin-left:8px;padding:4px 10px;cursor:pointer;border:1px solid #ccc;border-radius:4px;background:#f5f5f5;font-size:12px;vertical-align:middle;display:inline-flex;align-items:center;';
+            btn.style.cssText = BTN_STYLE;
 
             btn.onclick = function (e) {
                 e.preventDefault();


### PR DESCRIPTION
## Was

Der Button „Smart neu einstellen" in `addControlButtons()` trug denselben CSS-String wörtlich inline, den `BTN_STYLE` neun Zeilen darüber schon als Konstante hält — und den der Duplizieren-Button direkt daneben bereits nutzt.

```diff
-            btn.style.cssText = 'margin-left:8px;padding:4px 10px;cursor:pointer;border:1px solid #ccc;…';
+            btn.style.cssText = BTN_STYLE;
```

## Warum

Zwei Kopien, die gleich bleiben müssen, aber getrennt gepflegt werden: Eine Stiländerung an der Konstante hätte den Duplizieren-Button verändert und den Smart-Button unberührt gelassen — die beiden stehen im DOM direkt nebeneinander, das Auseinanderdriften wäre sofort sichtbar geworden.

## Risiko

Rein mechanisch. Der ersetzte String ist zeichengleich mit `BTN_STYLE`, das gerenderte CSS ist identisch. Kein Verhalten, keine Selektoren, kein Protokoll berührt.

## Verifikation

- `npm run validate` — Build meldet beide `@version` in sync (main 3.10.0, helper 1.11.0), Syntax-Check PASSED
- `npm test` — 198/198 grün, 11 Test-Dateien
- `git diff --stat` — eine geänderte Zeile, damit läuft auch der `git diff --exit-code`-Schritt der CI durch

Keine Versionsanhebung: Die Änderung ist für Nutzer nicht wahrnehmbar, ein Auto-Update wäre folgenlos.