### PR TITLE
refactor: Batch-Watchdog nutzt CONFIG.SAVE_WATCHDOG_TIMEOUT_MS

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -258,7 +258,7 @@ Bestätigungs-Seite (kein Zugriff durch den Helper):
 | Konstante | Wert | Datei | Bedeutung |
 |---|---|---|---|
 | `RESULT_WAIT_TIMEOUT_MS` | 180 000 ms (180s) | `helper.user.js` | Maximale Wartezeit des Helpers auf einen Result-Wert, bevor `code: 'timeout'` ausgelöst wird |
-| Watchdog-Delay | 45 000 ms (45s) | `kleinanzeigen-duplizieren.user.js` (`smartRepublish`) | Prüft nach dem Klick auf "Anzeige speichern", ob der Tab **noch** auf `p-anzeige-bearbeiten.html` steht; falls ja, schreibt er `error:save_failed:not_deleted` und raeumt den Loesch-Auftrag ab |
+| `CONFIG.SAVE_WATCHDOG_TIMEOUT_MS` | 45 000 ms (45s) | `kleinanzeigen-duplizieren.user.js` (`startSaveWatchdog()` und der Batch-Watchdog in `smartRepublish()`) | Prüft nach dem Klick auf "Anzeige speichern", ob der Tab **noch** auf `p-anzeige-bearbeiten.html` steht; falls ja, schreibt er `error:save_failed:not_deleted` und raeumt den Loesch-Auftrag ab |
 | Polling-Intervall | 1 000 ms | `helper.user.js` (`processOne`) | Fallback-Polling auf den Result-Key, redundant zum `storage`-Event |
 
 ## Kompatibilitätsregeln

--- a/kleinanzeigen-duplizieren.user.js
+++ b/kleinanzeigen-duplizieren.user.js
@@ -919,9 +919,14 @@
             saveBtn.click();
             startSaveWatchdog();
 
-            // B) Self-Watchdog: wenn der Tab nach 45s noch auf der Bearbeiten-Seite
-            // ist, hat das Save serverseitig nicht durchgegriffen. Ohne diesen
-            // Hinweis wuerde der Helper nur ein generisches Timeout sehen.
+            // B) Self-Watchdog: steht der Tab nach CONFIG.SAVE_WATCHDOG_TIMEOUT_MS
+            // noch auf der Bearbeiten-Seite, hat das Save serverseitig nicht
+            // durchgegriffen. Ohne diesen Hinweis wuerde der Helper nur ein
+            // generisches Timeout sehen. Bewusst dieselbe Frist wie
+            // startSaveWatchdog() oben -- beide beurteilen denselben Vorgang
+            // (Klick ohne Navigation), nur meldet der eine an den Nutzer und
+            // der andere an den Helper. Zwei getrennte Werte koennten
+            // auseinanderlaufen und den Batch anders bewerten als die UI.
             if (batchMode) {
                 setTimeout(function () {
                     try {
@@ -933,7 +938,7 @@
                             batchSetResult(originalId, 'error:save_failed:not_deleted');
                         }
                     } catch (e) {}
-                }, 45 * 1000);
+                }, CONFIG.SAVE_WATCHDOG_TIMEOUT_MS);
             }
 
         } catch (error) {


### PR DESCRIPTION
## Was

Der Self-Watchdog in `smartRepublish()` setzte seine Frist als Literal:

```diff
-                }, 45 * 1000);
+                }, CONFIG.SAVE_WATCHDOG_TIMEOUT_MS);
```

`CONFIG.SAVE_WATCHDOG_TIMEOUT_MS` steht mit exakt diesem Wert (45000) oben in `CONFIG`, und `startSaveWatchdog()` — vier Zeilen vorher aufgerufen — verwendet ihn bereits.

## Warum

Beide Watchdogs beurteilen denselben Vorgang: Klick auf „Anzeige speichern" ohne folgende Navigation. Sie melden ihn nur an verschiedene Adressaten — der eine an den Nutzer (Spinner freigeben, Fehlermeldung), der andere an den Helper (`error:save_failed:not_deleted` im Result-Key).

Laufen die Fristen auseinander, entsteht ein Fenster, in dem der Batch denselben Zustand anders bewertet als die sichtbare UI: Der Nutzer sähe „Speichern fehlgeschlagen", während der Helper noch wartet — oder umgekehrt der Helper meldete den Fehlschlag, während die Seite unverändert dasteht. Der geteilte Wert macht dieses Fenster strukturell unmöglich statt nur zufällig leer.

## Mitgeändert

- **Kommentar** nennt jetzt die Konstante statt „45s". Sonst wäre die Zahl an zweiter Stelle in Prosa zu pflegen — dasselbe Problem eine Ebene höher.
- **`PROTOCOL.md`**, Timing-Verträge: Die Zeile hieß „Watchdog-Delay", während die übrigen Zeilen der Tabelle echte Konstantennamen tragen. Sie heißt jetzt `CONFIG.SAVE_WATCHDOG_TIMEOUT_MS` und nennt beide Verwender.

## Risiko

Keiner. `45 * 1000 === 45000`, der Timing-Vertrag aus PROTOCOL.md bleibt bei 45 000 ms unverändert. Kein Result-Code, kein Storage-Schlüssel, kein Selektor berührt.

## Verifikation

- `npm run validate` — `@version` beider Scripts in sync (main 3.10.0, helper 1.11.0), Syntax-Check PASSED
- `npm test` — 198/198 grün, 11 Test-Dateien
- `grep -n "45 \* 1000\|45000\|45s"` über beide Scripts findet die Zahl nur noch in der `CONFIG`-Definition selbst

Keine Versionsanhebung: identisches Laufzeitverhalten, ein Auto-Update wäre folgenlos.