### PR TITLE
fix(helper): Stop bricht auch die Pause zwischen zwei Anzeigen ab

### DIFF
--- a/helper.user.js
+++ b/helper.user.js
@@ -5,7 +5,7 @@
 // @icon          https://www.kleinanzeigen.de/favicon.ico
 // @copyright     2026
 // @license       MIT
-// @version       1.11.0
+// @version       1.11.1
 // @author        panzli (Original), OldRon1977 (Anpassungen)
 // @credits       karlvonbonin - Idee und Grundlage der Auswahl im Batch-Overlay (PR #48)
 // @credits       Andi (Zer089) - Alter der Anzeige in Tagen mit Farbcode als Auswahlhilfe, Dashboard-Ansicht: https://github.com/Zer089/Kleinanzeigen.de-Anzeige_duplizieren_neu_einstellen
@@ -1462,7 +1462,13 @@
         cur.textContent = 'Aktuell: ' + (state.currentLabel || '\u2013');
         status.appendChild(cur);
 
-        if (state.nextEtaText) {
+        if (state.stopping) {
+            const note = document.createElement('div');
+            note.dataset.kaStopNote = 'true';
+            note.style.cssText = 'color:#e74c3c;margin-top:4px;font-weight:600;';
+            note.textContent = 'Stop angefordert – der laufende Vorgang wird noch zu Ende geführt.';
+            status.appendChild(note);
+        } else if (state.nextEtaText) {
             const eta = document.createElement('div');
             eta.style.cssText = 'color:#666;margin-top:4px;';
             eta.textContent = 'Nächste in: ' + state.nextEtaText;
@@ -1483,11 +1489,19 @@
 
         const actions = document.createElement('div');
         actions.style.cssText = 'padding:10px 14px;border-top:1px solid #eee;display:flex;gap:8px;justify-content:flex-end;';
-        const stop = makeButton('Stop', false);
+        const stop = makeButton(state.stopping ? 'Wird beendet \u2026' : 'Stop', false);
         stop.style.borderColor = '#e74c3c';
         stop.style.color = '#e74c3c';
         stop.style.background = '#fff';
         stop.style.fontWeight = '600';
+        // Nach dem ersten Klick ist nichts mehr anzufordern: ein zweiter Klick
+        // koennte nichts beschleunigen und wuerde nur so aussehen, als haette
+        // der erste nicht gewirkt.
+        stop.disabled = !!state.stopping;
+        if (state.stopping) {
+            stop.style.opacity = '0.6';
+            stop.style.cursor = 'not-allowed';
+        }
         stop.onclick = onStop;
         actions.appendChild(stop);
         overlay.appendChild(actions);
@@ -1710,17 +1724,38 @@
         });
     }
 
-    function waitMs(ms, onTick) {
+    // Wartet `ms` Millisekunden und meldet die Restzeit im Sekundentakt.
+    //
+    // `shouldAbort` wird bei JEDEM Tick geprueft, nicht nur am Ende. Ohne diese
+    // Pruefung wirkt ein Stop erst nach der Pause: bei der Standardeinstellung
+    // von 3-6 Minuten liefe der Ticker nach dem Klick noch minutenlang sichtbar
+    // weiter. Der Nutzer haelt das fuer kaputt und schliesst den Tab -- unter
+    // Umstaenden mitten im naechsten Vorgang, wo genau das teuer ist.
+    //
+    // Rueckgabe: true = ausgewartet, false = abgebrochen. Der Aufrufer muss den
+    // Unterschied kennen, weil nach einem Abbruch keine weitere Anzeige folgt.
+    function waitMs(ms, onTick, shouldAbort) {
         return new Promise(function (resolve) {
             const start = Date.now();
-            const tick = setInterval(function () {
+            const step = function () {
+                // Abbruch VOR der Restzeit-Meldung: ein abgebrochener Lauf soll
+                // keine neue ETA mehr in die Oberflaeche schreiben.
+                if (shouldAbort && shouldAbort()) {
+                    clearInterval(tick);
+                    resolve(false);
+                    return;
+                }
                 const remaining = Math.max(0, ms - (Date.now() - start));
                 if (onTick) onTick(remaining);
                 if (remaining <= 0) {
                     clearInterval(tick);
-                    resolve();
+                    resolve(true);
                 }
-            }, 1000);
+            };
+            const tick = setInterval(step, 1000);
+            // Einmal sofort: sonst bleibt die Restzeit die erste Sekunde leer,
+            // und ein Stop in genau dieser Sekunde wuerde erst danach bemerkt.
+            step();
         });
     }
 
@@ -1745,13 +1780,21 @@
             currentLabel: '',
             nextEtaText: '',
             aborted: false,
-            autoStopped: false
+            autoStopped: false,
+            stopping: false
         };
 
         const onStop = function () {
             stopRequested = true;
             state.aborted = true;
+            // Sofort neu zeichnen, damit der Klick sichtbar ankommt. Ein
+            // laufender Vorgang wird NICHT abgebrochen -- der Worker-Tab
+            // arbeitet zu Ende, sonst bliebe eine halb angelegte Anzeige
+            // zurueck. Der Hinweis sagt genau das, statt Sofort-Stop zu
+            // versprechen.
+            state.stopping = true;
             log('Stop angefordert');
+            renderProgress(state, onStop);
         };
 
         renderProgress(state, onStop);
@@ -1797,11 +1840,14 @@
                 const wait = randomDelayMs(delay);
                 if (wait > 0) {
                     log('Warte ' + Math.round(wait / 1000) + 's vor nächster Anzeige');
-                    await waitMs(wait, function (remaining) {
+                    const ausgewartet = await waitMs(wait, function (remaining) {
                         state.nextEtaText = formatRemaining(remaining);
                         renderProgress(state, onStop);
-                    });
+                    }, function () { return stopRequested; });
                     state.nextEtaText = '';
+                    if (!ausgewartet) {
+                        log('Stop während der Pause – Batch endet ohne weitere Anzeige');
+                    }
                 } else {
                     // 0/0: kein Ticker, keine Wartephase -- direkt weiter.
                     log('Keine Pause konfiguriert – nächste Anzeige folgt direkt');
@@ -1860,6 +1906,8 @@
             randomDelayMs,
             estimateRuntimeRange,
             formatRuntimeRange,
+            waitMs,
+            formatRemaining,
             renderConfirm,
             sanitize,
             crc32,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kleinanzeigen-anzeigen-duplizieren",
   "version": "3.10.0",
-  "helperVersion": "1.11.0",
+  "helperVersion": "1.11.1",
   "description": "eBay Kleinanzeigen - Anzeige duplizieren / neu einstellen. Einfaches Duplizieren und Smart Neu-Einstellen von Anzeigen mit automatischer Bilderhaltung",
   "main": "kleinanzeigen-duplizieren.user.js",
   "scripts": {

--- a/tests/helper.stop.test.js
+++ b/tests/helper.stop.test.js
@@ -1,0 +1,113 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import helper from '../helper.user.js';
+
+const { waitMs, formatRemaining } = helper;
+
+// Regressionsschutz fuer den Stop-Button waehrend der Pause zwischen zwei
+// Anzeigen. Vorher pruefte runBatch `stopRequested` erst NACH dem Warten --
+// bei der Standardpause von 3-6 Minuten lief der Ticker nach dem Klick also
+// noch minutenlang weiter, ohne dass sich sichtbar etwas tat.
+describe('waitMs', () => {
+    afterEach(() => { vi.useRealTimers(); });
+
+    it('wartet die volle Zeit aus und meldet true', async () => {
+        vi.useFakeTimers();
+        let fertig = null;
+        const p = waitMs(3000).then(v => { fertig = v; });
+
+        await vi.advanceTimersByTimeAsync(2000);
+        expect(fertig).toBeNull();
+
+        await vi.advanceTimersByTimeAsync(1000);
+        await p;
+        expect(fertig).toBe(true);
+    });
+
+    it('bricht beim naechsten Tick ab, wenn shouldAbort true wird, und meldet false', async () => {
+        vi.useFakeTimers();
+        let abbrechen = false;
+        let fertig = null;
+        // 10 Minuten -- laenger als jede realistische Pause, damit der Test
+        // wirklich den Abbruch misst und nicht das regulaere Ende.
+        const p = waitMs(600000, null, () => abbrechen).then(v => { fertig = v; });
+
+        await vi.advanceTimersByTimeAsync(5000);
+        expect(fertig).toBeNull();
+
+        abbrechen = true;
+        await vi.advanceTimersByTimeAsync(1000);
+        await p;
+        expect(fertig).toBe(false);
+    });
+
+    it('meldet die Restzeit sofort, nicht erst nach einer Sekunde', async () => {
+        vi.useFakeTimers();
+        const ticks = [];
+        const p = waitMs(5000, ms => ticks.push(ms));
+
+        // Ohne den Sofort-Tick bliebe die Restzeit die erste Sekunde leer.
+        expect(ticks.length).toBe(1);
+        expect(ticks[0]).toBe(5000);
+
+        await vi.advanceTimersByTimeAsync(5000);
+        await p;
+    });
+
+    it('schreibt nach dem Abbruch keine neue Restzeit mehr', async () => {
+        vi.useFakeTimers();
+        let abbrechen = false;
+        const ticks = [];
+        const p = waitMs(600000, ms => ticks.push(ms), () => abbrechen);
+
+        await vi.advanceTimersByTimeAsync(2000);
+        const vorAbbruch = ticks.length;
+
+        abbrechen = true;
+        await vi.advanceTimersByTimeAsync(5000);
+        await p;
+
+        // Der Abbruch-Tick darf onTick nicht mehr aufrufen, und danach laeuft
+        // kein Intervall weiter -- sonst stuende eine tote ETA in der UI.
+        expect(ticks.length).toBe(vorAbbruch);
+    });
+
+    it('laeuft ohne shouldAbort wie bisher', async () => {
+        vi.useFakeTimers();
+        let fertig = null;
+        const p = waitMs(1000, null).then(v => { fertig = v; });
+        await vi.advanceTimersByTimeAsync(1000);
+        await p;
+        expect(fertig).toBe(true);
+    });
+});
+
+describe('formatRemaining', () => {
+    it('formatiert Minuten und Sekunden zweistellig', () => {
+        expect(formatRemaining(0)).toBe('0:00');
+        expect(formatRemaining(9000)).toBe('0:09');
+        expect(formatRemaining(65000)).toBe('1:05');
+        expect(formatRemaining(600000)).toBe('10:00');
+    });
+});
+
+// Der Verhaltenstest oben deckt waitMs ab. Dass runBatch das Praedikat auch
+// tatsaechlich mitgibt, laesst sich ohne Mock des halben Batch-Ablaufs nicht
+// beobachten -- diese Struktur-Pruefung haelt genau die eine Verdrahtung fest,
+// die verloren gehen koennte.
+describe('runBatch reicht den Stop-Zustand an die Pause durch', () => {
+    const src = fs.readFileSync(path.resolve(process.cwd(), 'helper.user.js'), 'utf8');
+    const start = src.indexOf('async function runBatch(');
+    const fn = src.slice(start, src.indexOf('\n    }', start));
+
+    it('uebergibt stopRequested als Abbruch-Praedikat an waitMs', () => {
+        expect(start).toBeGreaterThan(-1);
+        expect(fn).toContain('function () { return stopRequested; }');
+    });
+
+    it('wertet den Rueckgabewert von waitMs aus', () => {
+        expect(fn).toContain('await waitMs(');
+        expect(fn).toMatch(/const \w+ = await waitMs\(/);
+    });
+});


### PR DESCRIPTION
## Das Problem

`runBatch()` prüft `stopRequested` erst **nach** dem Warten — die Prüfung sitzt am Schleifenkopf, die Pause davor:

```js
await waitMs(wait, …);      // laeuft unbeirrt zu Ende
…
if (stopRequested) break;   // erst hier
```

`waitMs()` kannte keinen Abbruch. Bei der Standardeinstellung von 3–6 Minuten tat sich nach einem Klick auf „Stop" also bis zu sechs Minuten lang sichtbar nichts: Der ETA-Ticker zählte weiter herunter, als wäre nichts geschehen. Dass der Batch danach tatsächlich endete, war dem Nutzer in diesem Moment nicht anzusehen.

Genau das ist der teure Teil: Wer glaubt, der Stop habe nicht gewirkt, schließt den Tab. Trifft das einen laufenden Worker-Vorgang, bleibt im schlechtesten Fall eine halb angelegte Anzeige zurück.

## Die Änderung

`waitMs()` nimmt ein Abbruch-Prädikat, das bei **jedem** Tick geprüft wird, und meldet über den Rückgabewert, ob es ausgewartet oder abgebrochen hat. `runBatch()` reicht `stopRequested` durch:

```js
const ausgewartet = await waitMs(wait, onTick, function () { return stopRequested; });
```

Der Abbruch greift damit innerhalb einer Sekunde statt am Ende der Pause.

## Mitgeändert: der Klick muss ankommen

Der Abbruch allein löst nur den halben Fall. Läuft gerade ein Vorgang (nicht die Pause), wirkt Stop weiterhin erst danach — und das ist Absicht: Ein laufender Worker-Tab wird **nicht** abgebrochen, sonst bliebe eine halb angelegte Anzeige zurück.

Damit der Nutzer den Unterschied zwischen „hat nicht gewirkt" und „wirkt gleich" sieht:

- `onStop` zeichnet sofort neu, statt nur Flags zu setzen
- die Fortschrittsanzeige sagt „Stop angefordert – der laufende Vorgang wird noch zu Ende geführt." — sie verspricht bewusst keinen Sofort-Stop
- der Stop-Button sperrt nach dem ersten Klick; ein zweiter könnte nichts beschleunigen und sähe nur so aus, als hätte der erste versagt

Nebenbei meldet `waitMs()` die Restzeit jetzt sofort statt erst nach einer Sekunde — vorher blieb die ETA-Zeile den ersten Tick lang leer.

## Tests

`waitMs` und `formatRemaining` sind exportiert, neue Datei `tests/helper.stop.test.js` mit 8 Tests:

- volle Zeit ausgewartet → `true`
- `shouldAbort` wird `true` → Abbruch beim nächsten Tick, `false`
- nach dem Abbruch kein weiterer `onTick` (keine tote ETA in der UI)
- Restzeit kommt sofort, nicht erst nach 1 s
- Aufruf ohne Prädikat verhält sich wie bisher
- `formatRemaining` Rand- und Normalfälle
- Struktur-Prüfung, dass `runBatch` das Prädikat wirklich durchreicht und den Rückgabewert auswertet

**Gegengeprüft:** Die fünf Verhaltenstests schlagen gegen die alte `waitMs` fehl (5 failed | 3 passed) — sie halten also wirklich das neue Verhalten fest und nicht nur sich selbst.

## Verifikation

- `npm run validate` — Syntax-Check PASSED, Header via `npm run build` synchronisiert
- `npm test` — 206/206 grün (vorher 198), 12 Test-Dateien

## Version

`helperVersion` 1.11.0 → **1.11.1**, Header per `npm run build` mitgezogen. Patch-Bump nach der Konvention aus `ca158fc`/`a469f72` (Helper-Änderung bumpt im selben Commit); Fix statt Feature, daher Patch.
