### PR TITLE
perf: Bilder fuer den Snapshot parallel laden statt nacheinander

### DIFF
--- a/kleinanzeigen-duplizieren.user.js
+++ b/kleinanzeigen-duplizieren.user.js
@@ -5,7 +5,7 @@
 // @icon          https://www.kleinanzeigen.de/favicon.ico
 // @copyright     2026
 // @license       MIT
-// @version       3.10.0
+// @version       3.10.1
 // @author        OldRon1977 (Improvements), J05HI (Original)
 // @credits       Basierend auf dem Original-Script von J05HI (https://gist.github.com/J05HI/9f3fc7a496e8baeff5a56e0c1a710bb5)
 // @credits       Andi (Zer089) - Selektoren des Werbeblockers, MIT-Lizenz: https://github.com/Zer089/Kleinanzeigen.de-Anzeige_duplizieren_neu_einstellen
@@ -37,7 +37,7 @@
 (function () {
     'use strict';
 
-    const SCRIPT_VERSION = '3.10.0'; // wird von scripts/build.js synchron zu package.json gehalten
+    const SCRIPT_VERSION = '3.10.1'; // wird von scripts/build.js synchron zu package.json gehalten
 
     // === KONSTANTEN ===
     const CONFIG = {
@@ -51,7 +51,13 @@
         POPUP_POLL_INTERVAL_MS: 200,
         POPUP_POLL_TIMEOUT_MS: 30000,
         POPUP_RECLICK_COOLDOWN_MS: 1000,
-        SAVE_WATCHDOG_TIMEOUT_MS: 45000
+        SAVE_WATCHDOG_TIMEOUT_MS: 45000,
+        // Gleichzeitige Bild-Downloads beim Snapshot. Bewusst niedrig: mehr
+        // bringt kaum noch etwas (der Browser deckelt Verbindungen pro Host
+        // ohnehin) und soll nicht nach einem Download-Sturm aussehen. Vier
+        // liegt unter dem, was eine normale Bildergalerie beim Seitenaufbau
+        // parallel laedt.
+        IMAGE_FETCH_CONCURRENCY: 4
     };
 
     // === LOGGING ===
@@ -771,19 +777,57 @@
         return await res.blob();
     }
 
+    /**
+     * Wendet `worker` auf alle `items` an, aber hoechstens `limit` davon
+     * gleichzeitig, und liefert die Ergebnisse in der REIHENFOLGE DER EINGABE
+     * zurueck -- nicht in der Reihenfolge, in der sie fertig wurden.
+     *
+     * Die Reihenfolge ist hier kein Schoenheitsdetail: Der Index im Array wird
+     * im Recovery-ZIP zum Dateinamen (image_01, image_02, ...) und ist damit
+     * die Bildreihenfolge der Anzeige. Ein Pool, der Ergebnisse einfach
+     * anhaengt, wuerde sie nach Antwortzeit sortieren -- das Titelbild landete
+     * dann irgendwo.
+     *
+     * `worker` darf nicht ablehnen: eine Rejection wuerde die uebrigen
+     * Laeufer verwaisen lassen. Aufrufer fangen ihre Fehler selbst ab und
+     * geben einen Platzhalter zurueck.
+     */
+    async function mapLimit(items, limit, worker) {
+        const results = new Array(items.length);
+        let next = 0;
+        const run = async function () {
+            while (true) {
+                const i = next++;
+                if (i >= items.length) return;
+                results[i] = await worker(items[i], i);
+            }
+        };
+        const pool = [];
+        const size = Math.max(1, Math.min(limit, items.length));
+        for (let i = 0; i < size; i++) pool.push(run());
+        await Promise.all(pool);
+        return results;
+    }
+
     async function buildSnapshot(adId) {
         const ff = readFormFields();
         const urls = collectImageUrls();
-        const images = [];
-        for (const u of urls) {
+        // Parallel statt nacheinander: Der Snapshot liegt im kritischen Pfad
+        // VOR dem Speichern-Klick, und eine Anzeige darf bis zu 20 Bilder
+        // haben. Sequenziell summierte sich das auf mehrere Sekunden, in denen
+        // der Nutzer nur den Spinner sah.
+        const images = await mapLimit(urls, CONFIG.IMAGE_FETCH_CONCURRENCY, async function (u) {
             try {
                 const blob = await fetchAsBlob(u);
-                images.push({ url: u, blob: blob, mime: blob.type || 'image/jpeg' });
+                return { url: u, blob: blob, mime: blob.type || 'image/jpeg' };
             } catch (e) {
+                // Ein fehlgeschlagenes Bild darf den Snapshot nicht kippen --
+                // der Rest ist immer noch die Rettung. Platzhalter mit URL,
+                // damit die Luecke im ZIP nachvollziehbar bleibt.
                 logger.warn('Bild-Fetch fehlgeschlagen, speichere nur URL', { url: u, error: String(e) });
-                images.push({ url: u, blob: null, mime: null });
+                return { url: u, blob: null, mime: null };
             }
-        }
+        });
         return {
             adId: String(adId),
             capturedAt: Date.now(),
@@ -1159,7 +1203,8 @@
             handleConfirmationPage,
             awaitFormReady,
             waitUntilPageLoaded,
-            findAdIdInput, describeAdIdLookup, describeAdIdResolution, getUrlAdId
+            findAdIdInput, describeAdIdLookup, describeAdIdResolution, getUrlAdId,
+            mapLimit, buildSnapshot
         };
         return; // im Test-Kontext keine Initialisierung/Timer
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kleinanzeigen-anzeigen-duplizieren",
-  "version": "3.10.0",
+  "version": "3.10.1",
   "helperVersion": "1.11.0",
   "description": "eBay Kleinanzeigen - Anzeige duplizieren / neu einstellen. Einfaches Duplizieren und Smart Neu-Einstellen von Anzeigen mit automatischer Bilderhaltung",
   "main": "kleinanzeigen-duplizieren.user.js",

--- a/tests/worker.maplimit.test.js
+++ b/tests/worker.maplimit.test.js
@@ -1,0 +1,141 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import worker from '../kleinanzeigen-duplizieren.user.js';
+
+const { mapLimit, CONFIG } = worker;
+
+const tick = ms => new Promise(r => setTimeout(r, ms));
+
+describe('mapLimit', () => {
+    it('liefert die Ergebnisse in der Reihenfolge der EINGABE, nicht der Fertigstellung', async () => {
+        // Absichtlich umgekehrte Laufzeiten: wer zuerst startet, wird zuletzt
+        // fertig. Ein Pool, der Ergebnisse anhaengt, kaeme hier verdreht heraus
+        // -- und im Recovery-ZIP waere die Bildreihenfolge der Anzeige dahin.
+        const items = ['a', 'b', 'c', 'd'];
+        const dauer = { a: 40, b: 30, c: 20, d: 10 };
+        const res = await mapLimit(items, 4, async (x) => { await tick(dauer[x]); return x.toUpperCase(); });
+        expect(res).toEqual(['A', 'B', 'C', 'D']);
+    });
+
+    it('haelt die Obergrenze fuer gleichzeitige Aufrufe ein', async () => {
+        let laufend = 0;
+        let maximum = 0;
+        const items = Array.from({ length: 20 }, (_, i) => i);
+        await mapLimit(items, 4, async () => {
+            laufend++;
+            maximum = Math.max(maximum, laufend);
+            await tick(5);
+            laufend--;
+        });
+        expect(maximum).toBe(4);
+    });
+
+    it('verarbeitet jedes Element genau einmal', async () => {
+        const items = Array.from({ length: 25 }, (_, i) => i);
+        const gesehen = [];
+        const res = await mapLimit(items, 4, async (x) => { gesehen.push(x); return x * 2; });
+        expect(gesehen.sort((a, b) => a - b)).toEqual(items);
+        expect(res).toEqual(items.map(x => x * 2));
+    });
+
+    it('reicht den Index an den Worker durch', async () => {
+        const res = await mapLimit(['x', 'y', 'z'], 2, async (item, i) => item + i);
+        expect(res).toEqual(['x0', 'y1', 'z2']);
+    });
+
+    it('kommt mit einer leeren Liste klar', async () => {
+        expect(await mapLimit([], 4, async () => 1)).toEqual([]);
+    });
+
+    it('kommt mit einem Limit groesser als die Liste klar', async () => {
+        expect(await mapLimit([1, 2], 10, async (x) => x + 1)).toEqual([2, 3]);
+    });
+
+    it('faellt bei Limit 0 auf einen Laeufer zurueck statt haengenzubleiben', async () => {
+        // Ohne die Untergrenze wuerde der Pool leer bleiben und Promise.all
+        // sofort aufloesen -- results waere ein Array aus lauter undefined.
+        expect(await mapLimit([1, 2, 3], 0, async (x) => x * 10)).toEqual([10, 20, 30]);
+    });
+
+    it('ist tatsaechlich nebenlaeufig und nicht nur sequenziell verpackt', async () => {
+        const items = Array.from({ length: 8 }, (_, i) => i);
+        const start = Date.now();
+        await mapLimit(items, 4, async () => { await tick(25); });
+        const dauer = Date.now() - start;
+        // Sequenziell waeren es ~200ms, mit vier Laeufern ~50ms. Die Schranke
+        // liegt bewusst weit dazwischen, damit langsame CI-Maschinen den Test
+        // nicht kippen.
+        expect(dauer).toBeLessThan(150);
+    });
+});
+
+describe('CONFIG.IMAGE_FETCH_CONCURRENCY', () => {
+    it('ist gesetzt und bleibt in einem vertretbaren Rahmen', () => {
+        expect(typeof CONFIG.IMAGE_FETCH_CONCURRENCY).toBe('number');
+        expect(CONFIG.IMAGE_FETCH_CONCURRENCY).toBeGreaterThanOrEqual(1);
+        // Nach oben gedeckelt: ein hoher Wert brauchte eine eigene Begruendung
+        // (Bot-Erkennung, Verbindungslimit des Browsers).
+        expect(CONFIG.IMAGE_FETCH_CONCURRENCY).toBeLessThanOrEqual(8);
+    });
+});
+
+// Der eigentliche Pfad: mapLimit isoliert zu pruefen reicht nicht, wenn
+// buildSnapshot die Ergebnisse hinterher doch wieder falsch einsammelt.
+describe('buildSnapshot sammelt die Bilder parallel und in Reihenfolge ein', () => {
+    const { buildSnapshot } = worker;
+
+    function setzeBilder(anzahl) {
+        document.body.innerHTML = Array.from({ length: anzahl }, (_, i) =>
+            `<img src="https://img.kleinanzeigen.de/api/v1/prod-ads/images/bild${i}?rule=$_59.JPG">`
+        ).join('');
+    }
+
+    afterEach(() => {
+        document.body.innerHTML = '';
+        delete globalThis.fetch;
+    });
+
+    it('behaelt die Reihenfolge der Bilder, auch wenn spaetere zuerst antworten', async () => {
+        setzeBilder(5);
+        // Umgekehrte Latenzen: das letzte Bild ist als erstes da.
+        globalThis.fetch = async (url) => {
+            const nr = Number(url.match(/bild(\d+)/)[1]);
+            await tick((5 - nr) * 12);
+            return { ok: true, blob: async () => ({ type: 'image/jpeg', _nr: nr }) };
+        };
+
+        const snap = await buildSnapshot('12345');
+        expect(snap.images.map(i => i.blob._nr)).toEqual([0, 1, 2, 3, 4]);
+        expect(snap.images.map(i => i.url.match(/bild(\d+)/)[1])).toEqual(['0', '1', '2', '3', '4']);
+    });
+
+    it('ersetzt ein fehlgeschlagenes Bild durch einen Platzhalter, ohne den Rest zu verlieren', async () => {
+        setzeBilder(4);
+        globalThis.fetch = async (url) => {
+            const nr = Number(url.match(/bild(\d+)/)[1]);
+            if (nr === 2) return { ok: false, status: 404 };
+            return { ok: true, blob: async () => ({ type: 'image/jpeg', _nr: nr }) };
+        };
+
+        const snap = await buildSnapshot('12345');
+        expect(snap.images.length).toBe(4);
+        // Der Platzhalter bleibt an SEINER Position -- sonst verschoeben sich
+        // alle nachfolgenden Bilder im Recovery-ZIP um eins.
+        expect(snap.images[2].blob).toBeNull();
+        expect(snap.images[2].url).toContain('bild2');
+        expect(snap.images.filter(i => i.blob !== null).length).toBe(3);
+    });
+
+    it('laeuft nebenlaeufig statt nacheinander', async () => {
+        setzeBilder(8);
+        globalThis.fetch = async () => {
+            await tick(25);
+            return { ok: true, blob: async () => ({ type: 'image/jpeg' }) };
+        };
+
+        const start = Date.now();
+        await buildSnapshot('12345');
+        const dauer = Date.now() - start;
+        // Sequenziell waeren es ~200ms.
+        expect(dauer).toBeLessThan(150);
+    });
+});


### PR DESCRIPTION
## Das Problem

`buildSnapshot()` holte die Bilder in einer `await`-Schleife, eines nach dem anderen:

```js
for (const u of urls) {
    const blob = await fetchAsBlob(u);   // erst wenn dieses da ist, startet das naechste
    images.push(…);
}
```

Der Snapshot liegt im kritischen Pfad **vor** dem Speichern-Klick, und eine Anzeige darf bis zu 20 Bilder haben. Sequenziell summierte sich das auf mehrere Sekunden, in denen der Nutzer nur den Spinner sah. Im Batch verlängerte es jeden einzelnen Durchlauf.

## Warum Parallelisieren hier tatsächlich die Lösung ist

Ich habe die Alternativen kurz gegengeprüft, bevor ich es umgesetzt habe:

- **Bilder gar nicht laden, nur URLs speichern** — fällt aus. Der Sinn des Snapshots ist, dass er die Löschung überlebt; danach sind die URLs unter Umständen tot.
- **Erst beim ZIP-Download laden** — fällt aus demselben Grund aus, dann ist das Original längst weg.
- **Parallel laden** — bleibt übrig, und es passt zum Umfeld: Ein normaler Seitenaufbau lädt eine Bildergalerie ohnehin parallel. Die bisherige, perfekt serialisierte Abfolge ist eher das ungewöhnliche Muster.

Zwei Auflagen musste die Umsetzung erfüllen, sonst wäre sie ein Rückschritt gewesen.

## Auflage 1: Reihenfolge

Der Array-Index wird in `downloadRecoveryZip()` zum Dateinamen:

```js
const idx = String(i + 1).padStart(2, '0');
files.push({ name: folder + 'image_' + idx + '.' + ext, data: buf });
```

Das ist die Bildreihenfolge der Anzeige. Ein Pool, der Ergebnisse einfach anhängt, sortiert sie nach Antwortzeit — das Titelbild landete dann irgendwo. Deshalb `mapLimit()`, das per Index in ein vorbelegtes Array schreibt und die **Eingabereihenfolge** garantiert.

Dasselbe gilt für Fehlschläge: Der Platzhalter `{ blob: null }` muss an **seiner** Position bleiben, sonst verschieben sich alle nachfolgenden Bilder im ZIP um eins.

## Auflage 2: Obergrenze

`CONFIG.IMAGE_FETCH_CONCURRENCY = 4`, bewusst niedrig. Mehr bringt kaum etwas, weil der Browser Verbindungen pro Host ohnehin deckelt, und 20 gleichzeitige Requests sollen nicht nach einem Download-Sturm aussehen. Vier liegt unter dem, was eine normale Bildergalerie beim Seitenaufbau parallel lädt.

Die Konstante steht in `CONFIG` und nicht als Literal im Aufruf — gleiche Linie wie #62.

## Fehlerverhalten

Unverändert: Ein fehlgeschlagenes Bild wird zum Platzhalter und kippt den Snapshot nicht. `mapLimit` verlangt ausdrücklich, dass der Worker nicht ablehnt (eine Rejection würde die übrigen Läufer verwaisen lassen) — der Aufrufer fängt seine Fehler selbst ab, wie vorher.

## Tests

12 neue Tests in `tests/worker.maplimit.test.js`, `mapLimit` und `buildSnapshot` dafür exportiert:

- `mapLimit`: Eingabereihenfolge bei umgekehrten Laufzeiten, Obergrenze wird eingehalten, jedes Element genau einmal, Index-Durchreiche, leere Liste, Limit > Liste, Limit 0 (fällt auf einen Läufer zurück statt hängenzubleiben), echte Nebenläufigkeit
- `buildSnapshot` mit gemocktem `fetch`: Reihenfolge bei umgekehrten Latenzen, Platzhalter-Position bei HTTP 404, Nebenläufigkeit

**Gegengeprüft** — beide Regressionen werden erkannt:

| Rückbau | Ergebnis |
|---|---|
| `buildSnapshot` wieder sequenziell | Nebenläufigkeits-Test fällt (223 ms statt < 150 ms) |
| `mapLimit` hängt an statt zu indizieren | drei Reihenfolge-Tests fallen |

## Verifikation

- `npm run validate` — Syntax-Check PASSED, `@version` und `SCRIPT_VERSION` per `npm run build` auf 3.10.1 synchronisiert
- `npm test` — 210/210 grün (vorher 198), 12 Test-Dateien

## Version

`version` 3.10.0 → **3.10.1**. Patch nach dem Vorbild von `e9cb0b2` (3.8.0 → 3.8.1); Laufzeitverhalten schneller, aber keine neue Funktion.